### PR TITLE
feat: add on_failure parameter to parsers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ License: MIT + file LICENSE
 Suggests: 
     knitr,
     rmarkdown,
+    glue,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -16,6 +16,8 @@
 #' 8. StrucGP
 #'
 #' @param x A character vector of structure strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -32,8 +34,8 @@
 #' auto_parse(x)
 #'
 #' @export
-auto_parse <- function(x) {
-  struc_parser_wrapper(x, do_auto_parse)
+auto_parse <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_auto_parse, on_failure = on_failure)
 }
 
 do_auto_parse <- function(x) {

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -11,6 +11,8 @@
 #' For more information about GlycoCT format, see the glycoct.md documentation.
 #'
 #' @param x A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -27,8 +29,8 @@
 #' parse_glycoct(glycoct)
 #'
 #' @export
-parse_glycoct <- function(x) {
-  struc_parser_wrapper(x, do_parse_glycoct)
+parse_glycoct <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_glycoct, on_failure = on_failure)
 }
 
 do_parse_glycoct <- function(x) {

--- a/R/parse-iupac-condensed.R
+++ b/R/parse-iupac-condensed.R
@@ -22,6 +22,8 @@
 #' In the second case, the anomer is "?2".
 #'
 #' @param x A character vector of IUPAC-condensed strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -32,8 +34,8 @@
 #' @seealso [parse_iupac_short()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_condensed <- function(x) {
-  struc_parser_wrapper(x, do_parse_iupac_condensed)
+parse_iupac_condensed <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_iupac_condensed, on_failure = on_failure)
 }
 
 do_parse_iupac_condensed <- function(x) {

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -4,6 +4,8 @@
 #' For more information about IUPAC-extended format, see \doi{10.1351/pac199668101919}.
 #'
 #' @param x A character vector of IUPAC-extended strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @details
 #' The function accepts both a Unicode format (using the Greek letters alpha/beta
@@ -22,8 +24,8 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_short()]
 #'
 #' @export
-parse_iupac_extended <- function(x) {
-  struc_parser_wrapper(x, do_parse_iupac_extended)
+parse_iupac_extended <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_iupac_extended, on_failure = on_failure)
 }
 
 

--- a/R/parse-iupac-short.R
+++ b/R/parse-iupac-short.R
@@ -15,6 +15,8 @@
 #' In the first case, the anomer is "a2". In the second case, the anomer is "?2".
 #'
 #' @param x A character vector of IUPAC-short strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -25,8 +27,8 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_short <- function(x) {
-  struc_parser_wrapper(x, do_parse_iupac_short)
+parse_iupac_short <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_iupac_short, on_failure = on_failure)
 }
 
 

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -4,6 +4,8 @@
 #' To know more about Linear Code, see [this article](https://www.jstage.jst.go.jp/article/tigg1989/14/77/14_77_127/_article).
 #'
 #' @param x A character vector of Linear Code strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -12,8 +14,8 @@
 #' parse_linear_code(linear_code)
 #'
 #' @export
-parse_linear_code <- function(x) {
-  struc_parser_wrapper(x, do_parse_linear_code)
+parse_linear_code <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_linear_code, on_failure = on_failure)
 }
 
 do_parse_linear_code <- function(x) {

--- a/R/parse-pglyco.R
+++ b/R/parse-pglyco.R
@@ -4,6 +4,8 @@
 #' See example below for the structure format.
 #'
 #' @param x A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -12,8 +14,8 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_pglyco_struc <- function(x) {
-  struc_parser_wrapper(x, do_parse_pglyco_struc)
+parse_pglyco_struc <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_pglyco_struc, on_failure = on_failure)
 }
 
 

--- a/R/parse-strucgp.R
+++ b/R/parse-strucgp.R
@@ -4,6 +4,8 @@
 #' See example below for the structure format.
 #'
 #' @param x A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -12,8 +14,8 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_strucgp_struc <- function(x) {
-  struc_parser_wrapper(x, do_parse_strucgp_struc)
+parse_strucgp_struc <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_strucgp_struc, on_failure = on_failure)
 }
 
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -5,6 +5,8 @@
 #' For more information about WURCS, see [WURCS](https://github.com/glycoinfo/WURCS/wiki).
 #'
 #' @param x A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -17,8 +19,8 @@
 #' parse_wurcs(wurcs)
 #'
 #' @export
-parse_wurcs <- function(x) {
-  struc_parser_wrapper(x, do_parse_wurcs)
+parse_wurcs <- function(x, on_failure = "error") {
+  struc_parser_wrapper(x, do_parse_wurcs, on_failure = on_failure)
 }
 
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -1,11 +1,25 @@
-# This wrapper function adds the following functionalities to a
-# structure parser function:
-# - Check input type;
-# - Vectorized parsing;
-# - More informative error messages;
-# - Preserve names of the input character vector.
-struc_parser_wrapper <- function(x, parser, call = rlang::caller_env()) {
+#' Wrap a structure parser with vectorization and failure handling.
+#'
+#' @param x A character vector of structure strings.
+#' @param parser A parser function that returns one glycan graph per string.
+#' @param on_failure How to handle parsing failures. `"error"` aborts when a
+#'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param call The call to report in user-facing errors.
+#'
+#' @return A [glyrepr::glycan_structure()] object.
+#' @noRd
+struc_parser_wrapper <- function(
+    x,
+    parser,
+    on_failure = "error",
+    call = rlang::caller_env()
+) {
   checkmate::assert_character(x)
+  on_failure <- rlang::arg_match(
+    on_failure,
+    values = c("error", "na"),
+    error_call = call
+  )
 
   # Preserve names from input
   original_names <- names(x)
@@ -15,46 +29,89 @@ struc_parser_wrapper <- function(x, parser, call = rlang::caller_env()) {
 
   # Handle edge case: all NA
   if (all(na_mask)) {
-    result <- glyrepr::glycan_structure(NA)
-    result <- result[rep(1, length(x))]
-    if (!is.null(original_names)) {
-      attr(result, "names") <- original_names
-    }
-    return(result)
+    return(make_na_glycan_structure(length(x), names = original_names))
   }
 
   # Get unique non-NA values to avoid redundant computation
   non_na_x <- x[!na_mask]
   unique_x <- unique(non_na_x)
 
-  # Parse only unique values
-  unique_graphs <- purrr::map(unique_x, purrr::possibly(parser, NA))
-  # Check for parsing failures (parser returned NA, not a graph)
-  # Use identical() to check if the result is exactly NA (scalar)
-  invalid_mask <- purrr::map_lgl(unique_graphs, ~ identical(.x, NA))
+  # Parse only unique values, while normalizing late validation failures
+  safe_parse_one_structure <- purrr::possibly(
+    parse_one_structure,
+    otherwise = NA
+  )
+  parsed_unique_structures <- purrr::map(
+    unique_x,
+    safe_parse_one_structure,
+    parser = parser
+  )
+
+  invalid_mask <- purrr::map_lgl(parsed_unique_structures, ~ identical(.x, NA))
   invalid_unique_x <- unique_x[invalid_mask]
-  if (length(invalid_unique_x) > 0) {
+  if (length(invalid_unique_x) > 0 && on_failure == "error") {
     cli::cli_abort("Can't parse: {.val {invalid_unique_x}}", call = call)
   }
 
-  # Create structure from parsed unique graphs
-  unique_structure <- glyrepr::as_glycan_structure(unique_graphs)
+  valid_unique_x <- unique_x[!invalid_mask]
+  valid_unique_structures <- parsed_unique_structures[!invalid_mask]
+
+  if (length(valid_unique_structures) == 0) {
+    return(make_na_glycan_structure(length(x), names = original_names))
+  }
+
+  valid_unique_iupacs <- purrr::map_chr(
+    valid_unique_structures,
+    ~ vctrs::vec_data(.x)[[1]]
+  )
+  graph_keep_mask <- !duplicated(valid_unique_iupacs)
+  valid_graphs <- purrr::map(
+    valid_unique_structures[graph_keep_mask],
+    ~ attr(.x, "graphs")[[1]]
+  )
+  names(valid_graphs) <- valid_unique_iupacs[graph_keep_mask]
 
   # Build result by directly constructing the IUPAC vector
-  # This avoids the expensive purrr::reduce() operation with c()
-  non_na_match_indices <- match(non_na_x, unique_x)
-  unique_iupacs <- vctrs::vec_data(unique_structure)
-  unique_graphs_list <- attr(unique_structure, "graphs")
+  non_na_match_indices <- match(non_na_x, valid_unique_x)
 
   result_iupacs <- character(length(x))
   result_iupacs[na_mask] <- NA_character_
-  result_iupacs[!na_mask] <- unique_iupacs[non_na_match_indices]
+  result_iupacs[!na_mask] <- valid_unique_iupacs[non_na_match_indices]
 
-  result <- glyrepr:::new_glycan_structure(result_iupacs, unique_graphs_list)
+  result <- glyrepr:::new_glycan_structure(result_iupacs, valid_graphs)
 
   # Restore names (only if input had names)
   if (!is.null(original_names)) {
     attr(result, "names") <- original_names
+  }
+  result
+}
+
+
+#' Parse a single structure string into a validated glycan structure.
+#'
+#' @param x A single structure string.
+#' @param parser A parser function that returns a glycan graph.
+#'
+#' @return A length-1 [glyrepr::glycan_structure()] object.
+#' @noRd
+parse_one_structure <- function(x, parser) {
+  glyrepr::as_glycan_structure(list(parser(x)))
+}
+
+
+#' Construct an all-`NA` glycan structure vector.
+#'
+#' @param n Desired length.
+#' @param names Optional names to restore on the result.
+#'
+#' @return A [glyrepr::glycan_structure()] object filled with `NA`.
+#' @noRd
+make_na_glycan_structure <- function(n, names = NULL) {
+  result <- glyrepr::glycan_structure(NA)
+  result <- result[rep(1, n)]
+  if (!is.null(names)) {
+    attr(result, "names") <- names
   }
   result
 }

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -14,29 +14,73 @@ struc_parser_wrapper <- function(
     on_failure = "error",
     call = rlang::caller_env()
 ) {
+  on_failure <- validate_struc_parser_wrapper_args(x, on_failure, call = call)
+  wrapper_input <- prepare_struc_parser_input(x)
+
+  if (wrapper_input$all_na) {
+    return(make_na_glycan_structure(wrapper_input$size, names = wrapper_input$names))
+  }
+
+  parsed_unique <- parse_unique_structures(wrapper_input$unique_x, parser)
+  abort_on_invalid_parse(parsed_unique$invalid_unique_x, on_failure, call = call)
+
+  if (length(parsed_unique$valid_unique_x) == 0) {
+    return(make_na_glycan_structure(wrapper_input$size, names = wrapper_input$names))
+  }
+
+  build_wrapped_structure(
+    wrapper_input = wrapper_input,
+    parsed_unique = parsed_unique
+  )
+}
+
+
+#' Validate wrapper arguments.
+#'
+#' @param x A character vector of structure strings.
+#' @param on_failure How to handle parsing failures.
+#' @param call The call to report in user-facing errors.
+#'
+#' @return The validated `on_failure` value.
+#' @noRd
+validate_struc_parser_wrapper_args <- function(x, on_failure, call) {
   checkmate::assert_character(x)
-  on_failure <- rlang::arg_match(
+  rlang::arg_match(
     on_failure,
     values = c("error", "na"),
     error_call = call
   )
+}
 
-  # Preserve names from input
-  original_names <- names(x)
 
-  # Identify NA positions
+#' Prepare vectorized parser input metadata.
+#'
+#' @param x A character vector of structure strings.
+#'
+#' @return A list with input metadata used by `struc_parser_wrapper()`.
+#' @noRd
+prepare_struc_parser_input <- function(x) {
   na_mask <- is.na(x)
-
-  # Handle edge case: all NA
-  if (all(na_mask)) {
-    return(make_na_glycan_structure(length(x), names = original_names))
-  }
-
-  # Get unique non-NA values to avoid redundant computation
   non_na_x <- x[!na_mask]
-  unique_x <- unique(non_na_x)
+  list(
+    size = length(x),
+    names = names(x),
+    na_mask = na_mask,
+    non_na_x = non_na_x,
+    unique_x = unique(non_na_x),
+    all_na = all(na_mask)
+  )
+}
 
-  # Parse only unique values, while normalizing late validation failures
+
+#' Parse unique input structures and separate failures.
+#'
+#' @param unique_x A character vector of unique, non-`NA` structure strings.
+#' @param parser A parser function that returns one glycan graph per string.
+#'
+#' @return A list containing valid and invalid unique parse results.
+#' @noRd
+parse_unique_structures <- function(unique_x, parser) {
   safe_parse_one_structure <- purrr::possibly(
     parse_one_structure,
     otherwise = NA
@@ -46,20 +90,70 @@ struc_parser_wrapper <- function(
     safe_parse_one_structure,
     parser = parser
   )
-
   invalid_mask <- purrr::map_lgl(parsed_unique_structures, ~ identical(.x, NA))
-  invalid_unique_x <- unique_x[invalid_mask]
+  list(
+    invalid_unique_x = unique_x[invalid_mask],
+    valid_unique_x = unique_x[!invalid_mask],
+    valid_unique_structures = parsed_unique_structures[!invalid_mask]
+  )
+}
+
+
+#' Abort on invalid parse inputs when requested.
+#'
+#' @param invalid_unique_x Unique structure strings that could not be parsed.
+#' @param on_failure How to handle parsing failures.
+#' @param call The call to report in user-facing errors.
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+abort_on_invalid_parse <- function(invalid_unique_x, on_failure, call) {
   if (length(invalid_unique_x) > 0 && on_failure == "error") {
     cli::cli_abort("Can't parse: {.val {invalid_unique_x}}", call = call)
   }
+  invisible(NULL)
+}
 
-  valid_unique_x <- unique_x[!invalid_mask]
-  valid_unique_structures <- parsed_unique_structures[!invalid_mask]
 
-  if (length(valid_unique_structures) == 0) {
-    return(make_na_glycan_structure(length(x), names = original_names))
+#' Build the final wrapped glycan structure result.
+#'
+#' @param wrapper_input Prepared input metadata.
+#' @param parsed_unique Parsed valid unique structures.
+#'
+#' @return A [glyrepr::glycan_structure()] object.
+#' @noRd
+build_wrapped_structure <- function(wrapper_input, parsed_unique) {
+  structure_payload <- extract_structure_payload(
+    parsed_unique$valid_unique_structures
+  )
+  non_na_match_indices <- match(
+    wrapper_input$non_na_x,
+    parsed_unique$valid_unique_x
+  )
+
+  result_iupacs <- character(wrapper_input$size)
+  result_iupacs[wrapper_input$na_mask] <- NA_character_
+  result_iupacs[!wrapper_input$na_mask] <-
+    structure_payload$iupacs[non_na_match_indices]
+
+  result <- glyrepr:::new_glycan_structure(
+    result_iupacs,
+    structure_payload$graphs
+  )
+  if (!is.null(wrapper_input$names)) {
+    attr(result, "names") <- wrapper_input$names
   }
+  result
+}
 
+
+#' Extract IUPAC codes and graph lookup payload from parsed structures.
+#'
+#' @param valid_unique_structures A list of length-1 glycan structures.
+#'
+#' @return A list with `iupacs` and named `graphs`.
+#' @noRd
+extract_structure_payload <- function(valid_unique_structures) {
   valid_unique_iupacs <- purrr::map_chr(
     valid_unique_structures,
     ~ vctrs::vec_data(.x)[[1]]
@@ -70,21 +164,10 @@ struc_parser_wrapper <- function(
     ~ attr(.x, "graphs")[[1]]
   )
   names(valid_graphs) <- valid_unique_iupacs[graph_keep_mask]
-
-  # Build result by directly constructing the IUPAC vector
-  non_na_match_indices <- match(non_na_x, valid_unique_x)
-
-  result_iupacs <- character(length(x))
-  result_iupacs[na_mask] <- NA_character_
-  result_iupacs[!na_mask] <- valid_unique_iupacs[non_na_match_indices]
-
-  result <- glyrepr:::new_glycan_structure(result_iupacs, valid_graphs)
-
-  # Restore names (only if input had names)
-  if (!is.null(original_names)) {
-    attr(result, "names") <- original_names
-  }
-  result
+  list(
+    iupacs = valid_unique_iupacs,
+    graphs = valid_graphs
+  )
 }
 
 

--- a/man/auto_parse.Rd
+++ b/man/auto_parse.Rd
@@ -4,10 +4,13 @@
 \alias{auto_parse}
 \title{Automatic Structure Parsing}
 \usage{
-auto_parse(x)
+auto_parse(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of structure strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -4,10 +4,13 @@
 \alias{parse_glycoct}
 \title{Parse GlycoCT Structures}
 \usage{
-parse_glycoct(x)
+parse_glycoct(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_condensed.Rd
+++ b/man/parse_iupac_condensed.Rd
@@ -4,10 +4,13 @@
 \alias{parse_iupac_condensed}
 \title{Parse IUPAC-condensed Structures}
 \usage{
-parse_iupac_condensed(x)
+parse_iupac_condensed(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of IUPAC-condensed strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_extended.Rd
+++ b/man/parse_iupac_extended.Rd
@@ -4,10 +4,13 @@
 \alias{parse_iupac_extended}
 \title{Parse IUPAC-extended Structures}
 \usage{
-parse_iupac_extended(x)
+parse_iupac_extended(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of IUPAC-extended strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_short.Rd
+++ b/man/parse_iupac_short.Rd
@@ -4,10 +4,13 @@
 \alias{parse_iupac_short}
 \title{Parse IUPAC-short Structures}
 \usage{
-parse_iupac_short(x)
+parse_iupac_short(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of IUPAC-short strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_linear_code.Rd
+++ b/man/parse_linear_code.Rd
@@ -4,10 +4,13 @@
 \alias{parse_linear_code}
 \title{Parse Linear Code Structures}
 \usage{
-parse_linear_code(x)
+parse_linear_code(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of Linear Code strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_pglyco_struc.Rd
+++ b/man/parse_pglyco_struc.Rd
@@ -4,10 +4,13 @@
 \alias{parse_pglyco_struc}
 \title{Parse pGlyco Structures}
 \usage{
-parse_pglyco_struc(x)
+parse_pglyco_struc(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_strucgp_struc.Rd
+++ b/man/parse_strucgp_struc.Rd
@@ -4,10 +4,13 @@
 \alias{parse_strucgp_struc}
 \title{Parse StrucGP Structures}
 \usage{
-parse_strucgp_struc(x)
+parse_strucgp_struc(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -4,10 +4,13 @@
 \alias{parse_wurcs}
 \title{Parse WURCS Structures}
 \usage{
-parse_wurcs(x)
+parse_wurcs(x, on_failure = "error")
 }
 \arguments{
 \item{x}{A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.}
+
+\item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
+structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/tests/testthat/test-na-support.R
+++ b/tests/testthat/test-na-support.R
@@ -104,18 +104,82 @@ test_that("auto_parse handles NA", {
   expect_true(is.na(result[2]))
 })
 
-test_that("invalid structures still error, not treated as NA", {
-  skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
-  expect_error(
-    parse_strucgp_struc(c("valid_structure", "invalid")),
-    "must have no NA in vertex attribute"
+parser_failure_cases <- list(
+  parse_pglyco_struc = list(
+    valid = "(N(F)(N(H)))",
+    invalid = "(N(X))"
+  ),
+  parse_strucgp_struc = list(
+    valid = "A2B2C1D1E2F1fedD1E2edcbB5ba",
+    invalid = "not_valid"
+  ),
+  parse_iupac_condensed = list(
+    valid = "Gal(b1-3)GlcNAc(b1-4)Glc(a1-",
+    invalid = "Gal(b1-3)Bogus(b1-4)Glc(a1-"
+  ),
+  parse_iupac_extended = list(
+    valid = "beta-D-Galp-(1->3)-alpha-D-GalpNAc-(1->",
+    invalid = "beta-D-Bogusp-(1->3)-alpha-D-GalpNAc-(1->"
+  ),
+  parse_iupac_short = list(
+    valid = "Neu5Aca3Gala3(Fuca6)GlcNAcb-",
+    invalid = "Bogusa3GlcNAcb-"
+  ),
+  parse_wurcs = list(
+    valid = paste0(
+      "WURCS=2.0/3,3,2/",
+      "[a2122h-1b_1-5_2*NCC/3=O]",
+      "[a1122h-1b_1-5]",
+      "[a1122h-1a_1-5]/1-2-3/a3-b1_b4-c1"
+    ),
+    invalid = "WURCS=2.0/1,1,0/[axxxxxh-1a_1-5]/1/"
+  ),
+  parse_linear_code = list(
+    valid = "Ma3(Ma6)Mb4GNb4GNb",
+    invalid = "Zz"
+  ),
+  parse_glycoct = list(
+    valid = "RES\n1b:b-dglc-HEX-1:5\nLIN\n1:1d(2+1)2n",
+    invalid = "LIN\n1:1d(2+1)2n"
+  ),
+  auto_parse = list(
+    valid = "Gal(b1-3)GlcNAc(b1-4)Glc(a1-",
+    invalid = "Gal(b1-3)Bogus(b1-4)Glc(a1-"
   )
+)
+
+purrr::iwalk(parser_failure_cases, function(case, parser_name) {
+  test_that(glue::glue("{parser_name} errors on invalid input by default"), {
+    skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
+
+    parser <- get(parser_name)
+
+    err <- rlang::catch_cnd(parser(c(case$valid, case$invalid)), classes = "error")
+
+    expect_s3_class(err, "error")
+    expect_match(conditionMessage(err), "Can't parse", fixed = TRUE)
+  })
+
+  test_that(glue::glue("{parser_name} returns NA for invalid input with on_failure = 'na'"), {
+    skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
+
+    parser <- get(parser_name)
+    input <- c(valid = case$valid, invalid = case$invalid)
+
+    result <- parser(input, on_failure = "na")
+
+    expect_equal(length(result), 2)
+    expect_equal(names(result), names(input))
+    expect_false(is.na(result[["valid"]]))
+    expect_true(is.na(result[["invalid"]]))
+  })
 })
 
-test_that("mixed valid and invalid structures error", {
+test_that("parser functions validate on_failure", {
   skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
+
   expect_error(
-    parse_strucgp_struc(c("A2B2C1D1E2F1fedD1E2edcbB5ba", "not_valid")),
-    "must have no NA in vertex attribute"
+    parse_iupac_condensed("Gal(b1-3)GlcNAc(b1-4)Glc(a1-", on_failure = "ignore"),
+    "`on_failure`"
   )
 })

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -13,6 +13,29 @@ test_that("struc_parser_wrapper handles duplicate values efficiently", {
   expect_length(unique_result, 3)
 })
 
+test_that("struc_parser_wrapper parses each unique non-NA input once", {
+  parser_calls <- character()
+  parser <- function(x) {
+    parser_calls <<- c(parser_calls, x)
+    graph <- igraph::make_empty_graph(n = 2, directed = TRUE)
+    igraph::V(graph)$name <- c("1", "2")
+    igraph::V(graph)$mono <- c("Hex", "Hex")
+    igraph::V(graph)$sub <- c("", "")
+    graph <- igraph::add_edges(graph, c("2", "1"))
+    igraph::E(graph)$linkage <- "a1-4"
+    graph$anomer <- "a1"
+    graph$alditol <- FALSE
+    graph
+  }
+
+  input <- c("A", "B", NA, "A", "C", "B")
+
+  result <- struc_parser_wrapper(input, parser, on_failure = "error")
+
+  expect_length(result, length(input))
+  expect_equal(parser_calls, c("A", "B", "C"))
+})
+
 test_that("struc_parser_wrapper preserves order with duplicates", {
   input <- c("(N)", "(H)", "(N)", "(F)", "(H)", "(N)")
   result <- parse_pglyco_struc(input)


### PR DESCRIPTION
## Summary

This PR adds an `on_failure` parameter to all glycan parsers, allowing users to control how parsing failures are handled.

### Changes
- Added `on_failure` parameter to `auto_parse()` and all individual parsers
- Refactored `struc_parser_wrapper()` to support the new parameter
- Added tests for NA support and performance
- Added `glue` to Suggests in DESCRIPTION

🤖 Generated with [Claude Code](https://claude.com/claude-code)