### PR TITLE
fix: improve WURCS parser handling of unknown and ambiguous residues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # glyparse (development version)
 
+## Minor improvements and bug fixes
+
+* `parse_wurcs()` now supports ambiguous `u` residues and unknown ring closure residues (`?` ring position).
+* `parse_wurcs()` now correctly handles WURCS N-sulfate substituent codes (`*NSO/3=O/3=O`).
+
 # glyparse 0.6.0
 
 ## New features

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -137,6 +137,69 @@ WURCS_MONO_REGEX <- c(
 )
 
 
+WURCS_AMBIGUOUS_MONO_REGEX <- c(
+  "GlcNAc" = "^u2122h_2\\*NCC/3=O",
+  "GalNAc" = "^u2112h_2\\*NCC/3=O",
+  "ManNAc" = "^u1122h_2\\*NCC/3=O",
+  "GulNAc" = "^u2212h_2\\*NCC/3=O",
+  "AltNAc" = "^u2111h_2\\*NCC/3=O",
+  "AllNAc" = "^u2222h_2\\*NCC/3=O",
+  "TalNAc" = "^u1112h_2\\*NCC/3=O",
+  "IdoNAc" = "^u2121h_2\\*NCC/3=O",
+
+  "GlcN" = "^u2122h_2\\*N(?!CC/3=O)",
+  "ManN" = "^u1122h_2\\*N(?!CC/3=O)",
+  "GalN" = "^u2112h_2\\*N(?!CC/3=O)",
+  "GulN" = "^u2212h_2\\*N(?!CC/3=O)",
+  "AltN" = "^u2111h_2\\*N(?!CC/3=O)",
+  "AllN" = "^u2222h_2\\*N(?!CC/3=O)",
+  "TalN" = "^u1112h_2\\*N(?!CC/3=O)",
+  "IdoN" = "^u2121h_2\\*N(?!CC/3=O)",
+
+  "GlcA" = "^u2122A",
+  "ManA" = "^u1122A",
+  "GalA" = "^u2112A",
+  "GulA" = "^u2212A",
+  "AltA" = "^u2111A",
+  "AllA" = "^u2222A",
+  "TalA" = "^u1112A",
+  "IdoA" = "^u2121A",
+
+  "Glc" = "^u2122h(?!_2\\*N(CC/3=O)?)",
+  "Man" = "^u1122h(?!_2\\*N(CC/3=O)?)",
+  "Gal" = "^u2112h(?!_2\\*N(CC/3=O)?)",
+  "Gul" = "^u2212h(?!_2\\*N(CC/3=O)?)",
+  "Alt" = "^u2111h(?!_2\\*N(CC/3=O)?)",
+  "All" = "^u2222h(?!_2\\*N(CC/3=O)?)",
+  "Tal" = "^u1112h(?!_2\\*N(CC/3=O)?)",
+  "Ido" = "^u2121h(?!_2\\*N(CC/3=O)?)",
+
+  "FucNAc" = "^u1221m_2\\*NCC/3=O",
+  "QuiNAc" = "^u2122m_2\\*NCC/3=O",
+  "RhaNAc" = "^u2211m_2\\*NCC/3=O",
+  "6dAltNAc" = "^u2111m_2\\*NCC/3=O",
+  "6dTalNAc" = "^u1112m_2\\*NCC/3=O",
+
+  "Fuc" = "^u1221m(?!_2\\*NCC/3=O)",
+  "Qui" = "^u2122m(?!_2\\*NCC/3=O|_2\\*N_4\\*N)",
+  "Rha" = "^u2211m(?!_2\\*NCC/3=O)",
+  "6dGul" = "^u2212m",
+  "6dAlt" = "^u2111m(?!_2\\*NCC/3=O)",
+  "6dTal" = "^u1112m(?!_2\\*NCC/3=O)",
+
+  "Oli" = "^ud122m",
+  "Tyv" = "^u1d22m",
+  "Abe" = "^u2d12m",
+  "Par" = "^u2d22m",
+  "Dig" = "^ud222m",
+  "Col" = "^u1d21m",
+  "Ara" = "^u211h",
+  "Lyx" = "^u221h",
+  "Xyl" = "^u212h",
+  "Rib" = "^u222h"
+)
+
+
 WURCS_SUB_REGEX <- c(
   "Me" = "OC",
   "Ac" = "OCC/3=O",
@@ -165,14 +228,28 @@ parse_residue <- function(residue) {
     ~ stringr::str_detect(residue, .x)
   )
   if (mono_idx == 0) {
-    cli::cli_abort("Unable to parse residue: {.str {residue}}")
-  }
-  mono <- names(WURCS_MONO_REGEX)[[mono_idx]]
+    ambiguous_mono_idx <- purrr::detect_index(
+      WURCS_AMBIGUOUS_MONO_REGEX,
+      ~ stringr::str_detect(residue, .x)
+    )
+    if (ambiguous_mono_idx == 0) {
+      cli::cli_abort("Unable to parse residue: {.str {residue}}")
+    }
+    mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
+    mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
+    anomer <- "??"
+  } else {
+    mono <- names(WURCS_MONO_REGEX)[[mono_idx]]
+    mono_pattern <- WURCS_MONO_REGEX[[mono_idx]]
 
-  # Get anomeric carbon and anomer
-  anomer_code <- stringr::str_extract(residue, "-(\\d+[abx])_", group = 1)
-  anomer <- stringr::str_replace(anomer_code, "x", "?")
-  anomer <- paste0(stringr::str_sub(anomer, 2), stringr::str_sub(anomer, 1, 1))
+    # Get anomeric carbon and anomer
+    anomer_code <- stringr::str_extract(residue, "-(\\d+[abx])_", group = 1)
+    anomer <- stringr::str_replace(anomer_code, "x", "?")
+    anomer <- paste0(
+      stringr::str_sub(anomer, 2),
+      stringr::str_sub(anomer, 1, 1)
+    )
+  }
 
   # Get substituent(s)
   # For Neu5Ac and Neu5Gc, we need special handling since the 5-position NAc/NGc
@@ -192,7 +269,7 @@ parse_residue <- function(residue) {
     }
   } else {
     # For other monosaccharides, use the standard approach
-    sub_code <- stringr::str_remove(residue, WURCS_MONO_REGEX[[mono_idx]])
+    sub_code <- stringr::str_remove(residue, mono_pattern)
   }
 
   if (sub_code == "") {

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -286,10 +286,6 @@ WURCS_SUB_REGEX <- c(
 #' @return A normalized substituent code.
 #' @noRd
 normalize_n_sulfate_sub_code <- function(residue, sub_code) {
-  if (sub_code != "SO/3=O/3=O") {
-    return(sub_code)
-  }
-
   n_sulfate_pos <- stringr::str_extract(
     residue,
     "_(\\d+|\\?)\\*NSO/3=O/3=O",
@@ -299,7 +295,14 @@ normalize_n_sulfate_sub_code <- function(residue, sub_code) {
     return(sub_code)
   }
 
-  stringr::str_glue("_{n_sulfate_pos}*OSO/3=O/3=O")
+  if (!stringr::str_starts(sub_code, "SO/3=O/3=O")) {
+    return(sub_code)
+  }
+
+  n_sulfate_sub_code <- stringr::str_glue(
+    "_{n_sulfate_pos}*OSO/3=O/3=O"
+  )
+  stringr::str_replace(sub_code, "^SO/3=O/3=O", n_sulfate_sub_code)
 }
 
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -137,6 +137,69 @@ WURCS_MONO_REGEX <- c(
 )
 
 
+WURCS_UNKNOWN_RING_MONO_REGEX <- c(
+  "GlcNAc" = "^a2122h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "GalNAc" = "^a2112h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "ManNAc" = "^a1122h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "GulNAc" = "^a2212h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "AltNAc" = "^a2111h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "AllNAc" = "^a2222h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "TalNAc" = "^a1112h-1[abx]_1-\\?_2\\*NCC/3=O",
+  "IdoNAc" = "^a2121h-1[abx]_1-\\?_2\\*NCC/3=O",
+
+  "GlcN" = "^a2122h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "ManN" = "^a1122h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "GalN" = "^a2112h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "GulN" = "^a2212h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "AltN" = "^a2111h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "AllN" = "^a2222h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "TalN" = "^a1112h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "IdoN" = "^a2121h-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+
+  "GlcA" = "^a2122A-1[abx]_1-\\?",
+  "ManA" = "^a1122A-1[abx]_1-\\?",
+  "GalA" = "^a2112A-1[abx]_1-\\?",
+  "GulA" = "^a2212A-1[abx]_1-\\?",
+  "AltA" = "^a2111A-1[abx]_1-\\?",
+  "AllA" = "^a2222A-1[abx]_1-\\?",
+  "TalA" = "^a1112A-1[abx]_1-\\?",
+  "IdoA" = "^a2121A-1[abx]_1-\\?",
+
+  "Glc" = "^a2122h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Man" = "^a1122h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Gal" = "^a2112h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Gul" = "^a2212h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Alt" = "^a2111h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "All" = "^a2222h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Tal" = "^a1112h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+  "Ido" = "^a2121h-1[abx]_1-\\?(?!_2\\*N(CC/3=O)?)",
+
+  "FucNAc" = "^a1221m-1[abx]_1-\\?_2\\*NCC/3=O",
+  "QuiNAc" = "^a2122m-1[abx]_1-\\?_2\\*NCC/3=O",
+  "RhaNAc" = "^a2211m-1[abx]_1-\\?_2\\*NCC/3=O",
+  "6dAltNAc" = "^a2111m-1[abx]_1-\\?_2\\*NCC/3=O",
+  "6dTalNAc" = "^a1112m-1[abx]_1-\\?_2\\*NCC/3=O",
+
+  "Fuc" = "^a1221m-1[abx]_1-\\?(?!_2\\*NCC/3=O)",
+  "Qui" = "^a2122m-1[abx]_1-\\?(?!_2\\*NCC/3=O|_2\\*N_4\\*N)",
+  "Rha" = "^a2211m-1[abx]_1-\\?(?!_2\\*NCC/3=O)",
+  "6dGul" = "^a2212m-1[abx]_1-\\?",
+  "6dAlt" = "^a2111m-1[abx]_1-\\?(?!_2\\*NCC/3=O)",
+  "6dTal" = "^a1112m-1[abx]_1-\\?(?!_2\\*NCC/3=O)",
+
+  "Oli" = "^ad122m-1[abx]_1-\\?",
+  "Tyv" = "^a1d22m-1[abx]_1-\\?",
+  "Abe" = "^a2d12m-1[abx]_1-\\?",
+  "Par" = "^a2d22m-1[abx]_1-\\?",
+  "Dig" = "^ad222m-1[abx]_1-\\?",
+  "Col" = "^a1d21m-1[abx]_1-\\?",
+  "Ara" = "^a211h-1[abx]_1-\\?",
+  "Lyx" = "^a221h-1[abx]_1-\\?",
+  "Xyl" = "^a212h-1[abx]_1-\\?",
+  "Rib" = "^a222h-1[abx]_1-\\?"
+)
+
+
 WURCS_AMBIGUOUS_MONO_REGEX <- c(
   "GlcNAc" = "^u2122h_2\\*NCC/3=O",
   "GalNAc" = "^u2112h_2\\*NCC/3=O",
@@ -228,16 +291,31 @@ parse_residue <- function(residue) {
     ~ stringr::str_detect(residue, .x)
   )
   if (mono_idx == 0) {
-    ambiguous_mono_idx <- purrr::detect_index(
-      WURCS_AMBIGUOUS_MONO_REGEX,
+    unknown_ring_mono_idx <- purrr::detect_index(
+      WURCS_UNKNOWN_RING_MONO_REGEX,
       ~ stringr::str_detect(residue, .x)
     )
-    if (ambiguous_mono_idx == 0) {
-      cli::cli_abort("Unable to parse residue: {.str {residue}}")
+    if (unknown_ring_mono_idx > 0) {
+      mono <- names(WURCS_UNKNOWN_RING_MONO_REGEX)[[unknown_ring_mono_idx]]
+      mono_pattern <- WURCS_UNKNOWN_RING_MONO_REGEX[[unknown_ring_mono_idx]]
+      anomer_code <- stringr::str_extract(residue, "-(\\d+[abx])_", group = 1)
+      anomer <- stringr::str_replace(anomer_code, "x", "?")
+      anomer <- paste0(
+        stringr::str_sub(anomer, 2),
+        stringr::str_sub(anomer, 1, 1)
+      )
+    } else {
+      ambiguous_mono_idx <- purrr::detect_index(
+        WURCS_AMBIGUOUS_MONO_REGEX,
+        ~ stringr::str_detect(residue, .x)
+      )
+      if (ambiguous_mono_idx == 0) {
+        cli::cli_abort("Unable to parse residue: {.str {residue}}")
+      }
+      mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
+      mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
+      anomer <- "??"
     }
-    mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
-    mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
-    anomer <- "??"
   } else {
     mono <- names(WURCS_MONO_REGEX)[[mono_idx]]
     mono_pattern <- WURCS_MONO_REGEX[[mono_idx]]

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -277,6 +277,32 @@ WURCS_SUB_REGEX <- c(
 )
 
 
+#' Restore WURCS N-sulfate as a sulfate substituent.
+#'
+#' @param residue A WURCS monosaccharide residue.
+#' @param sub_code The substituent part left after removing the matched
+#'   monosaccharide pattern.
+#'
+#' @return A normalized substituent code.
+#' @noRd
+normalize_n_sulfate_sub_code <- function(residue, sub_code) {
+  if (sub_code != "SO/3=O/3=O") {
+    return(sub_code)
+  }
+
+  n_sulfate_pos <- stringr::str_extract(
+    residue,
+    "_(\\d+|\\?)\\*NSO/3=O/3=O",
+    group = 1
+  )
+  if (is.na(n_sulfate_pos)) {
+    return(sub_code)
+  }
+
+  stringr::str_glue("_{n_sulfate_pos}*OSO/3=O/3=O")
+}
+
+
 parse_residue <- function(residue) {
   # This function accepts a WURCS residue (something in "[]"),
   # and returns a named vector of c(mono, anomer, sub)
@@ -349,6 +375,7 @@ parse_residue <- function(residue) {
     # For other monosaccharides, use the standard approach
     sub_code <- stringr::str_remove(residue, mono_pattern)
   }
+  sub_code <- normalize_n_sulfate_sub_code(residue, sub_code)
 
   if (sub_code == "") {
     sub <- ""

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -9,23 +9,33 @@
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
 struc_parser_wrapper <- function(
-    x,
-    parser,
-    on_failure = "error",
-    call = rlang::caller_env()
+  x,
+  parser,
+  on_failure = "error",
+  call = rlang::caller_env()
 ) {
   on_failure <- validate_struc_parser_wrapper_args(x, on_failure, call = call)
   wrapper_input <- prepare_struc_parser_input(x)
 
   if (wrapper_input$all_na) {
-    return(make_na_glycan_structure(wrapper_input$size, names = wrapper_input$names))
+    return(make_na_glycan_structure(
+      wrapper_input$size,
+      names = wrapper_input$names
+    ))
   }
 
   parsed_unique <- parse_unique_structures(wrapper_input$unique_x, parser)
-  abort_on_invalid_parse(parsed_unique$invalid_unique_x, on_failure, call = call)
+  abort_on_invalid_parse(
+    parsed_unique$invalid_unique_x,
+    on_failure,
+    call = call
+  )
 
   if (length(parsed_unique$valid_unique_x) == 0) {
-    return(make_na_glycan_structure(wrapper_input$size, names = wrapper_input$names))
+    return(make_na_glycan_structure(
+      wrapper_input$size,
+      names = wrapper_input$names
+    ))
   }
 
   build_wrapped_structure(

--- a/tests/testthat/test-na-support.R
+++ b/tests/testthat/test-na-support.R
@@ -154,32 +154,43 @@ purrr::iwalk(parser_failure_cases, function(case, parser_name) {
 
     parser <- get(parser_name)
 
-    err <- rlang::catch_cnd(parser(c(case$valid, case$invalid)), classes = "error")
+    err <- rlang::catch_cnd(
+      parser(c(case$valid, case$invalid)),
+      classes = "error"
+    )
 
     expect_s3_class(err, "error")
     expect_match(conditionMessage(err), "Can't parse", fixed = TRUE)
   })
 
-  test_that(glue::glue("{parser_name} returns NA for invalid input with on_failure = 'na'"), {
-    skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
+  test_that(
+    glue::glue(
+      "{parser_name} returns NA for invalid input with on_failure = 'na'"
+    ),
+    {
+      skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
 
-    parser <- get(parser_name)
-    input <- c(valid = case$valid, invalid = case$invalid)
+      parser <- get(parser_name)
+      input <- c(valid = case$valid, invalid = case$invalid)
 
-    result <- parser(input, on_failure = "na")
+      result <- parser(input, on_failure = "na")
 
-    expect_equal(length(result), 2)
-    expect_equal(names(result), names(input))
-    expect_false(is.na(result[["valid"]]))
-    expect_true(is.na(result[["invalid"]]))
-  })
+      expect_equal(length(result), 2)
+      expect_equal(names(result), names(input))
+      expect_false(is.na(result[["valid"]]))
+      expect_true(is.na(result[["invalid"]]))
+    }
+  )
 })
 
 test_that("parser functions validate on_failure", {
   skip_if_not_installed("glyrepr", minimum_version = "0.10.0")
 
   expect_error(
-    parse_iupac_condensed("Gal(b1-3)GlcNAc(b1-4)Glc(a1-", on_failure = "ignore"),
+    parse_iupac_condensed(
+      "Gal(b1-3)GlcNAc(b1-4)Glc(a1-",
+      on_failure = "ignore"
+    ),
     "`on_failure`"
   )
 })

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -806,6 +806,52 @@ test_that("parse_residue handles unknown ring closure", {
 })
 
 
+test_that("parse_residue handles N-sulfate on amino sugars", {
+  expect_n_sulfate_residue <- function(residue, mono, anomer) {
+    expect_equal(
+      parse_residue(residue),
+      c(mono = mono, anomer = anomer, sub = "2S")
+    )
+  }
+
+  hexn_codes <- c(
+    GlcN = "2122h",
+    ManN = "1122h",
+    GalN = "2112h",
+    GulN = "2212h",
+    AltN = "2111h",
+    AllN = "2222h",
+    TalN = "1112h",
+    IdoN = "2121h"
+  )
+
+  purrr::iwalk(
+    hexn_codes,
+    ~ expect_n_sulfate_residue(
+      stringr::str_glue("u{.x}_2*NSO/3=O/3=O"),
+      .y,
+      "??"
+    )
+  )
+  purrr::iwalk(
+    hexn_codes,
+    ~ expect_n_sulfate_residue(
+      stringr::str_glue("a{.x}-1x_1-5_2*NSO/3=O/3=O"),
+      .y,
+      "?1"
+    )
+  )
+  purrr::iwalk(
+    hexn_codes,
+    ~ expect_n_sulfate_residue(
+      stringr::str_glue("a{.x}-1x_1-?_2*NSO/3=O/3=O"),
+      .y,
+      "?1"
+    )
+  )
+})
+
+
 test_that("parse_wurcs correctly handles unknown linkages", {
   expect_equal(
     as.character(parse_wurcs(
@@ -856,6 +902,22 @@ test_that("parse_wurcs handles unknown ring closure", {
       "WURCS=2.0/5,6,5/[a2122h-1x_1-?_2*NCC/3=O][a1221m-1a_1-5][a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]/1-2-3-4-5-5/a4-c1_c4-d1_d3-e1_d6-f1_a?-b1"
     )),
     "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc(?1-"
+  )
+})
+
+
+test_that("parse_wurcs handles N-sulfate on amino sugars", {
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/2,2,1/[u2122h_2*NSO/3=O/3=O][a2122A-1x_1-5]/1-2/a?-b1"
+    )),
+    "GlcA(?1-?)GlcN2S(??-"
+  )
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/2,2,1/[u2122A][a2122h-1x_1-5_2*NSO/3=O/3=O]/1-2/a?-b1"
+    )),
+    "GlcN2S(?1-?)GlcA(??-"
   )
 })
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -807,10 +807,10 @@ test_that("parse_residue handles unknown ring closure", {
 
 
 test_that("parse_residue handles N-sulfate on amino sugars", {
-  expect_n_sulfate_residue <- function(residue, mono, anomer) {
+  expect_n_sulfate_residue <- function(residue, mono, anomer, sub = "2S") {
     expect_equal(
       parse_residue(residue),
-      c(mono = mono, anomer = anomer, sub = "2S")
+      c(mono = mono, anomer = anomer, sub = sub)
     )
   }
 
@@ -848,6 +848,24 @@ test_that("parse_residue handles N-sulfate on amino sugars", {
       .y,
       "?1"
     )
+  )
+  purrr::iwalk(
+    hexn_codes,
+    ~ expect_n_sulfate_residue(
+      stringr::str_glue("u{.x}_2*NSO/3=O/3=O_6*OSO/3=O/3=O"),
+      .y,
+      "??",
+      "2S,6S"
+    )
+  )
+
+  expect_equal(
+    parse_residue("a2122h-1x_1-5_2*NSO/3=O/3=O_6*OSO/3=O/3=O"),
+    c(mono = "GlcN", anomer = "?1", sub = "2S,6S")
+  )
+  expect_equal(
+    parse_residue("a2122h-1x_1-?_2*NSO/3=O/3=O_6*OSO/3=O/3=O"),
+    c(mono = "GlcN", anomer = "?1", sub = "2S,6S")
   )
 })
 
@@ -919,6 +937,14 @@ test_that("parse_wurcs handles N-sulfate on amino sugars", {
     )),
     "GlcN2S(?1-?)GlcA(??-"
   )
+
+  structure <- parse_wurcs(
+    "WURCS=2.0/1,1,0/[u2122h_2*NSO/3=O/3=O_6*OSO/3=O/3=O]/1/"
+  )
+  graph <- glyrepr::get_structure_graphs(structure)
+  expect_equal(igraph::vertex_attr(graph, "mono"), "GlcN")
+  expect_equal(igraph::vertex_attr(graph, "sub"), "2S,6S")
+  expect_equal(graph$anomer, "??")
 })
 
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -422,6 +422,201 @@ test_that("parse_residue knows unkown substituent linkages", {
 })
 
 
+test_that("parse_residue handles ambiguous u residues", {
+  expect_ambiguous_residue <- function(residue, mono, sub = "") {
+    expect_equal(
+      parse_residue(residue),
+      c(mono = mono, anomer = "??", sub = sub)
+    )
+  }
+
+  purrr::iwalk(
+    c(
+      Glc = "u2122h",
+      Man = "u1122h",
+      Gal = "u2112h",
+      Gul = "u2212h",
+      Alt = "u2111h",
+      All = "u2222h",
+      Tal = "u1112h",
+      Ido = "u2121h",
+      GlcA = "u2122A",
+      ManA = "u1122A",
+      GalA = "u2112A",
+      GulA = "u2212A",
+      AltA = "u2111A",
+      AllA = "u2222A",
+      TalA = "u1112A",
+      IdoA = "u2121A",
+      Fuc = "u1221m",
+      Qui = "u2122m",
+      Rha = "u2211m",
+      `6dGul` = "u2212m",
+      `6dAlt` = "u2111m",
+      `6dTal` = "u1112m",
+      Oli = "ud122m",
+      Tyv = "u1d22m",
+      Abe = "u2d12m",
+      Par = "u2d22m",
+      Dig = "ud222m",
+      Col = "u1d21m",
+      Ara = "u211h",
+      Lyx = "u221h",
+      Xyl = "u212h",
+      Rib = "u222h"
+    ),
+    ~ expect_ambiguous_residue(.x, .y)
+  )
+
+  purrr::iwalk(
+    c(
+      GlcNAc = "u2122h_2*NCC/3=O",
+      ManNAc = "u1122h_2*NCC/3=O",
+      GalNAc = "u2112h_2*NCC/3=O",
+      GulNAc = "u2212h_2*NCC/3=O",
+      AltNAc = "u2111h_2*NCC/3=O",
+      AllNAc = "u2222h_2*NCC/3=O",
+      TalNAc = "u1112h_2*NCC/3=O",
+      IdoNAc = "u2121h_2*NCC/3=O",
+      FucNAc = "u1221m_2*NCC/3=O",
+      QuiNAc = "u2122m_2*NCC/3=O",
+      RhaNAc = "u2211m_2*NCC/3=O",
+      `6dAltNAc` = "u2111m_2*NCC/3=O",
+      `6dTalNAc` = "u1112m_2*NCC/3=O"
+    ),
+    ~ expect_ambiguous_residue(.x, .y)
+  )
+
+  purrr::iwalk(
+    c(
+      GlcN = "u2122h_2*N",
+      ManN = "u1122h_2*N",
+      GalN = "u2112h_2*N",
+      GulN = "u2212h_2*N",
+      AltN = "u2111h_2*N",
+      AllN = "u2222h_2*N",
+      TalN = "u1112h_2*N",
+      IdoN = "u2121h_2*N"
+    ),
+    ~ expect_ambiguous_residue(.x, .y)
+  )
+
+  purrr::pwalk(
+    list(
+      c(
+        "u2122A_2*NCC/3=O",
+        "u1122A_2*NCC/3=O",
+        "u2112A_2*NCC/3=O",
+        "u2212A_2*NCC/3=O",
+        "u2111A_2*NCC/3=O",
+        "u2222A_2*NCC/3=O",
+        "u1112A_2*NCC/3=O",
+        "u2121A_2*NCC/3=O",
+        "u2212m_2*NCC/3=O",
+        "ud122m_2*NCC/3=O",
+        "u1d22m_2*NCC/3=O",
+        "u2d12m_2*NCC/3=O",
+        "u2d22m_2*NCC/3=O",
+        "ud222m_2*NCC/3=O",
+        "u1d21m_2*NCC/3=O",
+        "u211h_2*NCC/3=O",
+        "u221h_2*NCC/3=O",
+        "u212h_2*NCC/3=O",
+        "u222h_2*NCC/3=O"
+      ),
+      c(
+        "GlcA",
+        "ManA",
+        "GalA",
+        "GulA",
+        "AltA",
+        "AllA",
+        "TalA",
+        "IdoA",
+        "6dGul",
+        "Oli",
+        "Tyv",
+        "Abe",
+        "Par",
+        "Dig",
+        "Col",
+        "Ara",
+        "Lyx",
+        "Xyl",
+        "Rib"
+      ),
+      "2NAc"
+    ),
+    expect_ambiguous_residue
+  )
+
+  purrr::pwalk(
+    list(
+      c(
+        "u2122A_2*N",
+        "u1122A_2*N",
+        "u2112A_2*N",
+        "u2212A_2*N",
+        "u2111A_2*N",
+        "u2222A_2*N",
+        "u1112A_2*N",
+        "u2121A_2*N",
+        "u1221m_2*N",
+        "u2122m_2*N",
+        "u2211m_2*N",
+        "u2212m_2*N",
+        "u2111m_2*N",
+        "u1112m_2*N",
+        "ud122m_2*N",
+        "u1d22m_2*N",
+        "u2d12m_2*N",
+        "u2d22m_2*N",
+        "ud222m_2*N",
+        "u1d21m_2*N",
+        "u211h_2*N",
+        "u221h_2*N",
+        "u212h_2*N",
+        "u222h_2*N"
+      ),
+      c(
+        "GlcA",
+        "ManA",
+        "GalA",
+        "GulA",
+        "AltA",
+        "AllA",
+        "TalA",
+        "IdoA",
+        "Fuc",
+        "Qui",
+        "Rha",
+        "6dGul",
+        "6dAlt",
+        "6dTal",
+        "Oli",
+        "Tyv",
+        "Abe",
+        "Par",
+        "Dig",
+        "Col",
+        "Ara",
+        "Lyx",
+        "Xyl",
+        "Rib"
+      ),
+      "2N"
+    ),
+    expect_ambiguous_residue
+  )
+
+  expect_ambiguous_residue(
+    "u2122h_2*NCC/3=O_?*OSO/3=O/3=O",
+    "GlcNAc",
+    "?S"
+  )
+})
+
+
 test_that("parse_wurcs correctly handles unknown linkages", {
   expect_equal(
     as.character(parse_wurcs(
@@ -440,6 +635,28 @@ test_that("parse_wurcs correctly handles unknown linkages", {
       "WURCS=2.0/2,2,1/[a2112h-1a_1-5_2*NCC/3=O][a2112h-1a_1-5]/1-2/a3-b?"
     )),
     "Gal(a?-3)GalNAc(a1-"
+  )
+})
+
+
+test_that("parse_wurcs handles ambiguous u residues", {
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/3,4,3/[u2122h][a2112h-1b_1-5][a2122h-1b_1-5_2*NCC/3=O]/1-2-3-2/a4-b1_b3-c1_c4-d1"
+    )),
+    "Gal(b1-4)GlcNAc(b1-3)Gal(b1-4)Glc(??-"
+  )
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/2,2,1/[u2112h_2*NCC/3=O][a2112h-1a_1-5_2*NCC/3=O]/1-2/a6-b1"
+    )),
+    "GalNAc(a1-6)GalNAc(??-"
+  )
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/2,2,1/[u2122A][a2122h-1x_1-5_2*NCC/3=O]/1-2/a?-b1"
+    )),
+    "GlcNAc(?1-?)GlcA(??-"
   )
 })
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -617,6 +617,195 @@ test_that("parse_residue handles ambiguous u residues", {
 })
 
 
+test_that("parse_residue handles unknown ring closure", {
+  expect_unknown_ring_residue <- function(residue, mono, sub = "") {
+    expect_equal(
+      parse_residue(residue),
+      c(mono = mono, anomer = "?1", sub = sub)
+    )
+  }
+
+  purrr::iwalk(
+    c(
+      Glc = "a2122h-1x_1-?",
+      Man = "a1122h-1x_1-?",
+      Gal = "a2112h-1x_1-?",
+      Gul = "a2212h-1x_1-?",
+      Alt = "a2111h-1x_1-?",
+      All = "a2222h-1x_1-?",
+      Tal = "a1112h-1x_1-?",
+      Ido = "a2121h-1x_1-?",
+      GlcA = "a2122A-1x_1-?",
+      ManA = "a1122A-1x_1-?",
+      GalA = "a2112A-1x_1-?",
+      GulA = "a2212A-1x_1-?",
+      AltA = "a2111A-1x_1-?",
+      AllA = "a2222A-1x_1-?",
+      TalA = "a1112A-1x_1-?",
+      IdoA = "a2121A-1x_1-?",
+      Fuc = "a1221m-1x_1-?",
+      Qui = "a2122m-1x_1-?",
+      Rha = "a2211m-1x_1-?",
+      `6dGul` = "a2212m-1x_1-?",
+      `6dAlt` = "a2111m-1x_1-?",
+      `6dTal` = "a1112m-1x_1-?",
+      Oli = "ad122m-1x_1-?",
+      Tyv = "a1d22m-1x_1-?",
+      Abe = "a2d12m-1x_1-?",
+      Par = "a2d22m-1x_1-?",
+      Dig = "ad222m-1x_1-?",
+      Col = "a1d21m-1x_1-?",
+      Ara = "a211h-1x_1-?",
+      Lyx = "a221h-1x_1-?",
+      Xyl = "a212h-1x_1-?",
+      Rib = "a222h-1x_1-?"
+    ),
+    ~ expect_unknown_ring_residue(.x, .y)
+  )
+
+  purrr::iwalk(
+    c(
+      GlcNAc = "a2122h-1x_1-?_2*NCC/3=O",
+      ManNAc = "a1122h-1x_1-?_2*NCC/3=O",
+      GalNAc = "a2112h-1x_1-?_2*NCC/3=O",
+      GulNAc = "a2212h-1x_1-?_2*NCC/3=O",
+      AltNAc = "a2111h-1x_1-?_2*NCC/3=O",
+      AllNAc = "a2222h-1x_1-?_2*NCC/3=O",
+      TalNAc = "a1112h-1x_1-?_2*NCC/3=O",
+      IdoNAc = "a2121h-1x_1-?_2*NCC/3=O",
+      FucNAc = "a1221m-1x_1-?_2*NCC/3=O",
+      QuiNAc = "a2122m-1x_1-?_2*NCC/3=O",
+      RhaNAc = "a2211m-1x_1-?_2*NCC/3=O",
+      `6dAltNAc` = "a2111m-1x_1-?_2*NCC/3=O",
+      `6dTalNAc` = "a1112m-1x_1-?_2*NCC/3=O"
+    ),
+    ~ expect_unknown_ring_residue(.x, .y)
+  )
+
+  purrr::iwalk(
+    c(
+      GlcN = "a2122h-1x_1-?_2*N",
+      ManN = "a1122h-1x_1-?_2*N",
+      GalN = "a2112h-1x_1-?_2*N",
+      GulN = "a2212h-1x_1-?_2*N",
+      AltN = "a2111h-1x_1-?_2*N",
+      AllN = "a2222h-1x_1-?_2*N",
+      TalN = "a1112h-1x_1-?_2*N",
+      IdoN = "a2121h-1x_1-?_2*N"
+    ),
+    ~ expect_unknown_ring_residue(.x, .y)
+  )
+
+  purrr::pwalk(
+    list(
+      c(
+        "a2122A-1x_1-?_2*NCC/3=O",
+        "a1122A-1x_1-?_2*NCC/3=O",
+        "a2112A-1x_1-?_2*NCC/3=O",
+        "a2212A-1x_1-?_2*NCC/3=O",
+        "a2111A-1x_1-?_2*NCC/3=O",
+        "a2222A-1x_1-?_2*NCC/3=O",
+        "a1112A-1x_1-?_2*NCC/3=O",
+        "a2121A-1x_1-?_2*NCC/3=O",
+        "a2212m-1x_1-?_2*NCC/3=O",
+        "ad122m-1x_1-?_2*NCC/3=O",
+        "a1d22m-1x_1-?_2*NCC/3=O",
+        "a2d12m-1x_1-?_2*NCC/3=O",
+        "a2d22m-1x_1-?_2*NCC/3=O",
+        "ad222m-1x_1-?_2*NCC/3=O",
+        "a1d21m-1x_1-?_2*NCC/3=O",
+        "a211h-1x_1-?_2*NCC/3=O",
+        "a221h-1x_1-?_2*NCC/3=O",
+        "a212h-1x_1-?_2*NCC/3=O",
+        "a222h-1x_1-?_2*NCC/3=O"
+      ),
+      c(
+        "GlcA",
+        "ManA",
+        "GalA",
+        "GulA",
+        "AltA",
+        "AllA",
+        "TalA",
+        "IdoA",
+        "6dGul",
+        "Oli",
+        "Tyv",
+        "Abe",
+        "Par",
+        "Dig",
+        "Col",
+        "Ara",
+        "Lyx",
+        "Xyl",
+        "Rib"
+      ),
+      "2NAc"
+    ),
+    expect_unknown_ring_residue
+  )
+
+  purrr::pwalk(
+    list(
+      c(
+        "a2122A-1x_1-?_2*N",
+        "a1122A-1x_1-?_2*N",
+        "a2112A-1x_1-?_2*N",
+        "a2212A-1x_1-?_2*N",
+        "a2111A-1x_1-?_2*N",
+        "a2222A-1x_1-?_2*N",
+        "a1112A-1x_1-?_2*N",
+        "a2121A-1x_1-?_2*N",
+        "a1221m-1x_1-?_2*N",
+        "a2122m-1x_1-?_2*N",
+        "a2211m-1x_1-?_2*N",
+        "a2212m-1x_1-?_2*N",
+        "a2111m-1x_1-?_2*N",
+        "a1112m-1x_1-?_2*N",
+        "ad122m-1x_1-?_2*N",
+        "a1d22m-1x_1-?_2*N",
+        "a2d12m-1x_1-?_2*N",
+        "a2d22m-1x_1-?_2*N",
+        "ad222m-1x_1-?_2*N",
+        "a1d21m-1x_1-?_2*N",
+        "a211h-1x_1-?_2*N",
+        "a221h-1x_1-?_2*N",
+        "a212h-1x_1-?_2*N",
+        "a222h-1x_1-?_2*N"
+      ),
+      c(
+        "GlcA",
+        "ManA",
+        "GalA",
+        "GulA",
+        "AltA",
+        "AllA",
+        "TalA",
+        "IdoA",
+        "Fuc",
+        "Qui",
+        "Rha",
+        "6dGul",
+        "6dAlt",
+        "6dTal",
+        "Oli",
+        "Tyv",
+        "Abe",
+        "Par",
+        "Dig",
+        "Col",
+        "Ara",
+        "Lyx",
+        "Xyl",
+        "Rib"
+      ),
+      "2N"
+    ),
+    expect_unknown_ring_residue
+  )
+})
+
+
 test_that("parse_wurcs correctly handles unknown linkages", {
   expect_equal(
     as.character(parse_wurcs(
@@ -657,6 +846,16 @@ test_that("parse_wurcs handles ambiguous u residues", {
       "WURCS=2.0/2,2,1/[u2122A][a2122h-1x_1-5_2*NCC/3=O]/1-2/a?-b1"
     )),
     "GlcNAc(?1-?)GlcA(??-"
+  )
+})
+
+
+test_that("parse_wurcs handles unknown ring closure", {
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/5,6,5/[a2122h-1x_1-?_2*NCC/3=O][a1221m-1a_1-5][a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]/1-2-3-4-5-5/a4-c1_c4-d1_d3-e1_d6-f1_a?-b1"
+    )),
+    "Man(a1-3)[Man(a1-6)]Man(b1-4)GlcNAc(b1-4)[Fuc(a1-?)]GlcNAc(?1-"
   )
 })
 


### PR DESCRIPTION
## Summary
- Support unknown WURCS ring closure residues (residues with `?` ring position in the monosaccharide backbone pattern)
- Support ambiguous `u` residues in WURCS parser (residues where anomeric configuration is unspecified and ring size is unspecified)
- Restore WURCS N-sulfate substituents in `parse_residue` by normalizing `*NSO/3=O/3=O` to the correct `*OSO/3=O/3=O` substituent form

## Test plan
- New test cases added in `test-parse-wurcs.R` for unknown ring and ambiguous residue parsing
- Updated tests in `test-na-support.R`