### PR TITLE
fix: handle WURCS alditol residues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,3 +36,4 @@ Depends:
 VignetteBuilder: knitr
 BugReports: https://github.com/glycoverse/glyparse/issues
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    glyrepr (>= 0.9.0),
+    glyrepr (>= 0.12.0),
     igraph,
     purrr,
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyparse (development version)
 
+## Minor improvements and bug fixes
+
+* `parse_wurcs()` now parses WURCS alditol residues as regular reducing-end glycans with unknown anomer configurations. (#21)
+
 # glyparse 0.6.1
 
 ## Minor improvements and bug fixes

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -3,6 +3,8 @@
 #' This function parses WURCS strings into a [glyrepr::glycan_structure()].
 #' Currently, only WURCS 2.0 is supported.
 #' For more information about WURCS, see [WURCS](https://github.com/glycoinfo/WURCS/wiki).
+#' Alditol residues are parsed as regular reducing-end glycans with unknown
+#' anomer configurations.
 #'
 #' @param x A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
@@ -263,6 +265,81 @@ WURCS_AMBIGUOUS_MONO_REGEX <- c(
 )
 
 
+WURCS_ALDITOL_MONO_REGEX <- c(
+  "MurNAc" = "^h2122h_2\\*NCC/3=O_3\\*OC\\^RCO/4=O/3C",
+  "MurNGc" = "^h2122h_2\\*NCCO/3=O_3\\*OC\\^RCO/4=O/3C",
+  "Mur" = "^h2122h_3\\*OC\\^RCO/4=O/3C",
+
+  "GlcNAc" = "^h2122h_2\\*NCC/3=O",
+  "GalNAc" = "^h2112h_2\\*NCC/3=O",
+  "ManNAc" = "^h1122h_2\\*NCC/3=O",
+  "GulNAc" = "^h2212h_2\\*NCC/3=O",
+  "AltNAc" = "^h2221h_5\\*NCC/3=O",
+  "AllNAc" = "^h2222h_2\\*NCC/3=O",
+  "TalNAc" = "^h1222h_5\\*NCC/3=O",
+  "IdoNAc" = "^h2121h_2\\*NCC/3=O",
+
+  "GlcN" = "^h2122h_2\\*N",
+  "ManN" = "^h1122h_2\\*N",
+  "GalN" = "^h2112h_2\\*N",
+  "GulN" = "^h2212h_2\\*N",
+  "AltN" = "^h2221h_5\\*N",
+  "AllN" = "^h2222h_2\\*N",
+  "TalN" = "^h1222h_5\\*N",
+  "IdoN" = "^h2121h_2\\*N",
+
+  "Glc" = "^h2122h",
+  "Man" = "^h1122h",
+  "Gal" = "^h2112h",
+  "Gul" = "^h2212h",
+  "Alt" = "^h2221h",
+  "All" = "^h2222h",
+  "Tal" = "^h1222h",
+  "Ido" = "^h2121h",
+
+  "FucNAc" = "^h1221m_2\\*NCC/3=O",
+  "QuiNAc" = "^h2122m_2\\*NCC/3=O",
+  "RhaNAc" = "^h2211m_2\\*NCC/3=O",
+  "6dAltNAc" = "^h2111m_2\\*NCC/3=O",
+  "6dTalNAc" = "^h1112m_2\\*NCC/3=O",
+
+  "Bac" = "^h2122m_2\\*N_4\\*N",
+  "Fuc" = "^h1221m",
+  "Qui" = "^h2122m",
+  "Rha" = "^h2211m",
+  "6dGul" = "^h2212m",
+  "6dAlt" = "^h2111m",
+  "6dTal" = "^h1112m",
+
+  "Oli" = "^hd122m",
+  "Tyv" = "^h1d22m",
+  "Abe" = "^h2d12m",
+  "Par" = "^h2d22m",
+  "Dig" = "^hd222m",
+  "Col" = "^h1d21m",
+  "Lyx" = "^h221h",
+  "Xyl" = "^h212h",
+  "Rib" = "^h222h",
+
+  "Neu5Ac" = "^hUd21122h_5\\*NCC/3=O",
+  "Neu5Gc" = "^hUd21122h_5\\*NCCO/3=O",
+  "Neu" = "^hUd21122h_5\\*N",
+  "Kdn" = "^hUd21122h",
+  "Pse" = "^hUd22111m_5\\*N_7\\*N",
+  "Leg" = "^hUd21122m_5\\*N_7\\*N",
+  "Aci" = "^hUd21111m_5\\*N_7\\*N",
+  "4eLeg" = "^hUd11122m_5\\*N_7\\*N",
+  "LDmanHep" = "^h21122h",
+  "Kdo" = "^hUd1122h",
+  "Dha" = "^A122dUh",
+  "DDmanHep" = "^h11222h",
+  "Fru" = "^hU122h",
+  "Tag" = "^hU112h",
+  "Sor" = "^hU121h",
+  "Psi" = "^hU222h"
+)
+
+
 WURCS_SUB_REGEX <- c(
   "Me" = "OC",
   "Ac" = "OCC/3=O",
@@ -275,6 +352,34 @@ WURCS_SUB_REGEX <- c(
   "PEtn" = "OP(\\^X)?OCCN/3O/3=O",
   "N" = "N"
 )
+
+
+#' Detect whether a WURCS residue is an alditol descriptor.
+#'
+#' @param residue A WURCS monosaccharide residue.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_wurcs_alditol_residue <- function(residue) {
+  purrr::detect_index(
+    WURCS_ALDITOL_MONO_REGEX,
+    ~ stringr::str_detect(residue, .x)
+  ) >
+    0
+}
+
+
+#' Warn about alditol normalization in WURCS parsing.
+#'
+#' @return `NULL`, invisibly.
+#' @noRd
+warn_wurcs_alditol <- function() {
+  cli::cli_warn(c(
+    "Alditol WURCS residues are parsed as regular reducing-end glycans with unknown anomer configurations.",
+    "i" = "For example, GlcNAc-ol is returned as GlcNAc(?1-."
+  ))
+  invisible(NULL)
+}
 
 
 #' Restore WURCS N-sulfate as a sulfate substituent.
@@ -314,6 +419,8 @@ parse_residue <- function(residue) {
   # `sub`: the substituent, e.g. "3Me", "2Ac", "4NAc", "6P", "?P"
   #        for multiple substituents, they are separated by commas, e.g. "3Me,6S"
 
+  is_alditol <- FALSE
+
   # Get monosaacharide name
   mono_idx <- purrr::detect_index(
     WURCS_MONO_REGEX,
@@ -334,16 +441,27 @@ parse_residue <- function(residue) {
         stringr::str_sub(anomer, 1, 1)
       )
     } else {
-      ambiguous_mono_idx <- purrr::detect_index(
-        WURCS_AMBIGUOUS_MONO_REGEX,
+      alditol_mono_idx <- purrr::detect_index(
+        WURCS_ALDITOL_MONO_REGEX,
         ~ stringr::str_detect(residue, .x)
       )
-      if (ambiguous_mono_idx == 0) {
-        cli::cli_abort("Unable to parse residue: {.str {residue}}")
+      if (alditol_mono_idx > 0) {
+        mono <- names(WURCS_ALDITOL_MONO_REGEX)[[alditol_mono_idx]]
+        mono_pattern <- WURCS_ALDITOL_MONO_REGEX[[alditol_mono_idx]]
+        anomer <- paste0("?", glyrepr::get_anomer_pos(mono))
+        is_alditol <- TRUE
+      } else {
+        ambiguous_mono_idx <- purrr::detect_index(
+          WURCS_AMBIGUOUS_MONO_REGEX,
+          ~ stringr::str_detect(residue, .x)
+        )
+        if (ambiguous_mono_idx == 0) {
+          cli::cli_abort("Unable to parse residue: {.str {residue}}")
+        }
+        mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
+        mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
+        anomer <- "??"
       }
-      mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
-      mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
-      anomer <- "??"
     }
   } else {
     mono <- names(WURCS_MONO_REGEX)[[mono_idx]]
@@ -361,7 +479,7 @@ parse_residue <- function(residue) {
   # Get substituent(s)
   # For Neu5Ac and Neu5Gc, we need special handling since the 5-position NAc/NGc
   # is part of the monosaccharide itself, not an additional substituent
-  if (mono %in% c("Neu5Ac", "Neu5Gc")) {
+  if (mono %in% c("Neu5Ac", "Neu5Gc") && !is_alditol) {
     # For Neu5Ac/Neu5Gc, remove the base Kdn structure and the characteristic 5-position modification
     base_kdn_pattern <- "^Aad21122h-2[abx]_2-6"
     if (mono == "Neu5Ac") {
@@ -420,11 +538,22 @@ parse_residue <- function(residue) {
 }
 
 
+#' Extract WURCS residue descriptors.
+#'
+#' @param x A WURCS string or unique residue part.
+#'
+#' @return A character vector of residue descriptors without square brackets.
+#' @noRd
+extract_wurcs_residues <- function(x) {
+  residues <- stringr::str_extract_all(x, "\\[.*?\\]")[[1]]
+  stringr::str_sub(residues, 2, -2)
+}
+
+
 parse_unique_residues <- function(x) {
   # Input: a string of WURCS unique residues part
   # Output: a list of named vectors, each vector contains `mono`, `anomer`, and `sub`
-  residues <- stringr::str_extract_all(x, "\\[.*?\\]")[[1]]
-  residues <- stringr::str_sub(residues, 2, -2)
+  residues <- extract_wurcs_residues(x)
   purrr::map(residues, parse_residue)
 }
 
@@ -555,7 +684,13 @@ do_parse_wurcs <- function(x) {
   # unique_residues: a list of named character vectors,
   # each vector contains `mono` ("GlcNAc"), `anomer` ("b1"), and `sub` ("3Me")
   unique_residue_part <- stringr::str_extract(x, wurcs_regex, group = 1)
-  unique_residues <- parse_unique_residues(x)
+  unique_residue_descriptors <- extract_wurcs_residues(unique_residue_part)
+  unique_residues <- parse_unique_residues(unique_residue_part)
+  if (
+    any(purrr::map_lgl(unique_residue_descriptors, is_wurcs_alditol_residue))
+  ) {
+    warn_wurcs_alditol()
+  }
 
   # residue_sequence: an integer vector of monosaccharide indices,
   # referring to the order of unique_residues, repeated monosaccharides allowed.

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -19,6 +19,8 @@ A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.
 This function parses WURCS strings into a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.
 Currently, only WURCS 2.0 is supported.
 For more information about WURCS, see \href{https://github.com/glycoinfo/WURCS/wiki}{WURCS}.
+Alditol residues are parsed as regular reducing-end glycans with unknown
+anomer configurations.
 }
 \examples{
 wurcs <- paste0(

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -870,6 +870,108 @@ test_that("parse_residue handles N-sulfate on amino sugars", {
 })
 
 
+test_that("parse_residue handles alditol residues", {
+  expect_alditol_residue <- function(residue, mono) {
+    anomer <- paste0("?", glyrepr::get_anomer_pos(mono))
+    expect_equal(
+      parse_residue(residue),
+      c(mono = mono, anomer = anomer, sub = "")
+    )
+  }
+
+  alditol_residues <- c(
+    Glc = "h2122h",
+    Man = "h1122h",
+    Gal = "h2112h",
+    Gul = "h2212h",
+    Alt = "h2221h",
+    All = "h2222h",
+    Tal = "h1222h",
+    Ido = "h2121h",
+    GlcNAc = "h2122h_2*NCC/3=O",
+    GalNAc = "h2112h_2*NCC/3=O",
+    ManNAc = "h1122h_2*NCC/3=O",
+    GulNAc = "h2212h_2*NCC/3=O",
+    AltNAc = "h2221h_5*NCC/3=O",
+    AllNAc = "h2222h_2*NCC/3=O",
+    TalNAc = "h1222h_5*NCC/3=O",
+    IdoNAc = "h2121h_2*NCC/3=O",
+    GlcN = "h2122h_2*N",
+    ManN = "h1122h_2*N",
+    GalN = "h2112h_2*N",
+    GulN = "h2212h_2*N",
+    AltN = "h2221h_5*N",
+    AllN = "h2222h_2*N",
+    TalN = "h1222h_5*N",
+    IdoN = "h2121h_2*N",
+    Fuc = "h1221m",
+    Qui = "h2122m",
+    Rha = "h2211m",
+    `6dGul` = "h2212m",
+    `6dAlt` = "h2111m",
+    `6dTal` = "h1112m",
+    FucNAc = "h1221m_2*NCC/3=O",
+    QuiNAc = "h2122m_2*NCC/3=O",
+    RhaNAc = "h2211m_2*NCC/3=O",
+    `6dAltNAc` = "h2111m_2*NCC/3=O",
+    `6dTalNAc` = "h1112m_2*NCC/3=O",
+    Oli = "hd122m",
+    Tyv = "h1d22m",
+    Abe = "h2d12m",
+    Par = "h2d22m",
+    Dig = "hd222m",
+    Col = "h1d21m",
+    Lyx = "h221h",
+    Xyl = "h212h",
+    Rib = "h222h",
+    Neu5Ac = "hUd21122h_5*NCC/3=O",
+    Neu5Gc = "hUd21122h_5*NCCO/3=O",
+    Kdn = "hUd21122h",
+    Neu = "hUd21122h_5*N",
+    Pse = "hUd22111m_5*N_7*N",
+    Leg = "hUd21122m_5*N_7*N",
+    Aci = "hUd21111m_5*N_7*N",
+    `4eLeg` = "hUd11122m_5*N_7*N",
+    Bac = "h2122m_2*N_4*N",
+    LDmanHep = "h21122h",
+    Kdo = "hUd1122h",
+    Dha = "A122dUh",
+    DDmanHep = "h11222h",
+    MurNAc = "h2122h_2*NCC/3=O_3*OC^RCO/4=O/3C",
+    MurNGc = "h2122h_2*NCCO/3=O_3*OC^RCO/4=O/3C",
+    Mur = "h2122h_3*OC^RCO/4=O/3C",
+    Fru = "hU122h",
+    Tag = "hU112h",
+    Sor = "hU121h",
+    Psi = "hU222h"
+  )
+
+  purrr::iwalk(alditol_residues, ~ expect_alditol_residue(.x, .y))
+
+  # GlycanFormatConverter emits h221h for both Ara-ol and Lyx-ol. WURCS
+  # canonicalizes that alditol descriptor back to Lyx-ol, so parse the distinct
+  # descriptor deterministically.
+  expect_alditol_residue("h221h", "Lyx")
+})
+
+
+test_that("parse_wurcs warns and uses unknown reducing-end anomers for alditols", {
+  glcnac_alditol <- "WURCS=2.0/1,1,0/[h2122h_2*NCC/3=O]/1/"
+  expect_warning(
+    glcnac_structure <- parse_wurcs(glcnac_alditol),
+    "regular reducing-end glycans with unknown anomer configurations"
+  )
+  expect_equal(as.character(glcnac_structure), "GlcNAc(?1-")
+
+  linked_alditol <- "WURCS=2.0/2,2,1/[h2122h_2*NCC/3=O][a2112h-1b_1-5]/1-2/a4-b1"
+  expect_warning(
+    linked_structure <- parse_wurcs(linked_alditol),
+    "regular reducing-end glycans with unknown anomer configurations"
+  )
+  expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc(?1-")
+})
+
+
 test_that("parse_wurcs correctly handles unknown linkages", {
   expect_equal(
     as.character(parse_wurcs(


### PR DESCRIPTION
## Summary

Adds WURCS alditol support to `parse_wurcs()` by normalizing alditol residues to regular reducing-end glycans with unknown anomer configurations.

## Details

- Adds WURCS alditol residue matching across the parser's supported monosaccharide vocabulary.
- Uses `glyrepr::get_anomer_pos()` to assign unknown reducing-end anomers such as `?1` or `?2`.
- Raises the `glyrepr` dependency floor to `>= 0.12.0`, the first local tagged release exporting `get_anomer_pos()`.
- Emits a warning when alditol WURCS residues are parsed this way.
- Adds comprehensive parser tests for alditol residue descriptors plus public `parse_wurcs()` warning/output behavior.
- Regenerates `parse_wurcs()` documentation.
- Adds a development NEWS entry for this change.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "parse-wurcs")'` -> 410 passed
- `Rscript -e 'devtools::test()'` -> 718 passed
- `git diff --check` -> clean