### PR TITLE
Improve WURCS residue coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor improvements and bug fixes
 
+* `parse_wurcs()` now supports additional generic WURCS residue descriptors, ambiguous sialic descriptors, and uppercase residue IDs for large structures. (#23)
 * `parse_wurcs()` now parses WURCS alditol residues as regular reducing-end glycans with unknown anomer configurations. (#21)
 * `parse_glycoct()` now parses GlycoCT alditol residues as regular reducing-end glycans with unknown anomer configurations. (#22)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Minor improvements and bug fixes
 
-* `parse_wurcs()` now supports additional generic WURCS residue descriptors, ambiguous sialic descriptors, and uppercase residue IDs for large structures. (#23)
+* `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
+* `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
+* `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
 * `parse_wurcs()` now parses WURCS alditol residues as regular reducing-end glycans with unknown anomer configurations. (#21)
 * `parse_glycoct()` now parses GlycoCT alditol residues as regular reducing-end glycans with unknown anomer configurations. (#22)
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -139,6 +139,7 @@ WURCS_MONO_REGEX <- c(
   "dHexNAc" = "^axxxxm-1[abx]_1-5_2\\*NCC/3=O",
   "dHex" = "^axxxxm-1[abx]_1-5",
   "Pen" = "^axxxh-1[abx]_1-5",
+  "dHexNAc" = "^a2112m-1[abx]_1-5_2\\*NCC/3=O",
   "dHex" = "^a2112m-1[abx]_1-5",
   "Fru" = "^ha122h-2[abx]_2-6",
   "Tag" = "^ha112h-2[abx]_2-6",
@@ -214,15 +215,16 @@ WURCS_UNKNOWN_RING_MONO_REGEX <- c(
   "dHexNAc" = "^axxxxm-1[abx]_1-\\?_2\\*NCC/3=O",
   "dHex" = "^axxxxm-1[abx]_1-\\?",
   "Pen" = "^axxxh-1[abx]_1-\\?",
+  "dHexNAc" = "^a2112m-1[abx]_1-\\?_2\\*NCC/3=O",
   "dHex" = "^a2112m-1[abx]_1-\\?",
   "dHex" = "^a4334m-1[abx]_1-\\?"
 )
 
 
 WURCS_AMBIGUOUS_MONO_REGEX <- c(
-  "Neu5Ac" = "^AUd21122h_5\\*NCC/3=O",
-  "Neu5Gc" = "^AUd21122h_5\\*NCCO/3=O",
-  "Neu" = "^AUd21122h_5\\*N",
+  "Neu5Ac" = "^AUd21122h.*_5\\*NCC/3=O",
+  "Neu5Gc" = "^AUd21122h.*_5\\*NCCO/3=O",
+  "Neu" = "^AUd21122h.*_5\\*N",
   "Kdn" = "^AUd21122h",
 
   "GlcNAc" = "^u2122h_2\\*NCC/3=O",
@@ -291,6 +293,7 @@ WURCS_AMBIGUOUS_MONO_REGEX <- c(
   "dHexNAc" = "^uxxxxm_2\\*NCC/3=O",
   "dHex" = "^uxxxxm",
   "Pen" = "^uxxxh",
+  "dHexNAc" = "^u2112m_2\\*NCC/3=O",
   "dHex" = "^u2112m"
 )
 
@@ -558,6 +561,20 @@ parse_residue <- function(residue) {
       # Remove the base Kdn pattern and the 5*NCCO/3=O
       sub_code <- stringr::str_remove(residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
+    }
+  } else if (
+    mono %in%
+      c("Neu5Ac", "Neu5Gc", "Neu") &&
+      stringr::str_starts(residue, "AUd")
+  ) {
+    base_kdn_pattern <- "^AUd21122h"
+    sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+    if (mono == "Neu5Ac") {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
+    } else if (mono == "Neu5Gc") {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
+    } else {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*N(?!CC(O)?/3=O)")
     }
   } else {
     # For other monosaccharides, use the standard approach

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -132,6 +132,14 @@ WURCS_MONO_REGEX <- c(
   "MurNAc" = "^a2122h-1[abx]_1-5_2\\*NCC/3=O_3\\*OC\\^RCO/4=O/3C",
   "MurNGc" = "^a2122h-1[abx]_1-5_2\\*NCCO/3=O_3\\*OC\\^RCO/4=O/3C",
   "Mur" = "^a2122h-1[abx]_1-5_3\\*OC\\^RCO/4=O/3C",
+  "HexNAc" = "^axxxxh-1[abx]_1-5_2\\*NCC/3=O",
+  "HexN" = "^axxxxh-1[abx]_1-5_2\\*N(?!CC/3=O)",
+  "HexA" = "^axxxxA-1[abx]_1-5",
+  "Hex" = "^axxxxh-1[abx]_1-5",
+  "dHexNAc" = "^axxxxm-1[abx]_1-5_2\\*NCC/3=O",
+  "dHex" = "^axxxxm-1[abx]_1-5",
+  "Pen" = "^axxxh-1[abx]_1-5",
+  "dHex" = "^a2112m-1[abx]_1-5",
   "Fru" = "^ha122h-2[abx]_2-6",
   "Tag" = "^ha112h-2[abx]_2-6",
   "Sor" = "^ha121h-2[abx]_2-6",
@@ -198,11 +206,25 @@ WURCS_UNKNOWN_RING_MONO_REGEX <- c(
   "Ara" = "^a211h-1[abx]_1-\\?",
   "Lyx" = "^a221h-1[abx]_1-\\?",
   "Xyl" = "^a212h-1[abx]_1-\\?",
-  "Rib" = "^a222h-1[abx]_1-\\?"
+  "Rib" = "^a222h-1[abx]_1-\\?",
+  "HexNAc" = "^axxxxh-1[abx]_1-\\?_2\\*NCC/3=O",
+  "HexN" = "^axxxxh-1[abx]_1-\\?_2\\*N(?!CC/3=O)",
+  "HexA" = "^axxxxA-1[abx]_1-\\?",
+  "Hex" = "^axxxxh-1[abx]_1-\\?",
+  "dHexNAc" = "^axxxxm-1[abx]_1-\\?_2\\*NCC/3=O",
+  "dHex" = "^axxxxm-1[abx]_1-\\?",
+  "Pen" = "^axxxh-1[abx]_1-\\?",
+  "dHex" = "^a2112m-1[abx]_1-\\?",
+  "dHex" = "^a4334m-1[abx]_1-\\?"
 )
 
 
 WURCS_AMBIGUOUS_MONO_REGEX <- c(
+  "Neu5Ac" = "^AUd21122h_5\\*NCC/3=O",
+  "Neu5Gc" = "^AUd21122h_5\\*NCCO/3=O",
+  "Neu" = "^AUd21122h_5\\*N",
+  "Kdn" = "^AUd21122h",
+
   "GlcNAc" = "^u2122h_2\\*NCC/3=O",
   "GalNAc" = "^u2112h_2\\*NCC/3=O",
   "ManNAc" = "^u1122h_2\\*NCC/3=O",
@@ -261,7 +283,15 @@ WURCS_AMBIGUOUS_MONO_REGEX <- c(
   "Ara" = "^u211h",
   "Lyx" = "^u221h",
   "Xyl" = "^u212h",
-  "Rib" = "^u222h"
+  "Rib" = "^u222h",
+  "HexNAc" = "^uxxxxh_2\\*NCC/3=O",
+  "HexN" = "^uxxxxh_2\\*N(?!CC/3=O)",
+  "HexA" = "^uxxxxA",
+  "Hex" = "^uxxxxh",
+  "dHexNAc" = "^uxxxxm_2\\*NCC/3=O",
+  "dHex" = "^uxxxxm",
+  "Pen" = "^uxxxh",
+  "dHex" = "^u2112m"
 )
 
 
@@ -336,7 +366,14 @@ WURCS_ALDITOL_MONO_REGEX <- c(
   "Fru" = "^hU122h",
   "Tag" = "^hU112h",
   "Sor" = "^hU121h",
-  "Psi" = "^hU222h"
+  "Psi" = "^hU222h",
+  "HexNAc" = "^hxxxxh_2\\*NCC/3=O",
+  "HexN" = "^hxxxxh_2\\*N(?!CC/3=O)",
+  "HexA" = "^hxxxxA",
+  "Hex" = "^hxxxxh",
+  "dHexNAc" = "^hxxxxm_2\\*NCC/3=O",
+  "dHex" = "^hxxxxm",
+  "Pen" = "^hxxxh"
 )
 
 
@@ -411,6 +448,31 @@ normalize_n_sulfate_sub_code <- function(residue, sub_code) {
 }
 
 
+#' Get the anomeric position used for alditol normalization.
+#'
+#' @param mono A monosaccharide name.
+#'
+#' @return A character scalar containing the anomeric position.
+#' @noRd
+wurcs_anomer_pos <- function(mono) {
+  switch(
+    mono,
+    Hex = "1",
+    HexNAc = "1",
+    HexN = "1",
+    HexA = "1",
+    dHex = "1",
+    dHexNAc = "1",
+    Pen = "1",
+    Neu5Ac = "2",
+    Neu5Gc = "2",
+    Neu = "2",
+    Kdn = "2",
+    glyrepr::get_anomer_pos(mono)
+  )
+}
+
+
 parse_residue <- function(residue) {
   # This function accepts a WURCS residue (something in "[]"),
   # and returns a named vector of c(mono, anomer, sub)
@@ -448,7 +510,7 @@ parse_residue <- function(residue) {
       if (alditol_mono_idx > 0) {
         mono <- names(WURCS_ALDITOL_MONO_REGEX)[[alditol_mono_idx]]
         mono_pattern <- WURCS_ALDITOL_MONO_REGEX[[alditol_mono_idx]]
-        anomer <- paste0("?", glyrepr::get_anomer_pos(mono))
+        anomer <- paste0("?", wurcs_anomer_pos(mono))
         is_alditol <- TRUE
       } else {
         ambiguous_mono_idx <- purrr::detect_index(
@@ -479,7 +541,12 @@ parse_residue <- function(residue) {
   # Get substituent(s)
   # For Neu5Ac and Neu5Gc, we need special handling since the 5-position NAc/NGc
   # is part of the monosaccharide itself, not an additional substituent
-  if (mono %in% c("Neu5Ac", "Neu5Gc") && !is_alditol) {
+  if (
+    mono %in%
+      c("Neu5Ac", "Neu5Gc") &&
+      !is_alditol &&
+      stringr::str_starts(residue, "Aad")
+  ) {
     # For Neu5Ac/Neu5Gc, remove the base Kdn structure and the characteristic 5-position modification
     base_kdn_pattern <- "^Aad21122h-2[abx]_2-6"
     if (mono == "Neu5Ac") {
@@ -618,7 +685,13 @@ parse_one_linkage <- function(x) {
 }
 
 letter_to_int <- function(letter) {
-  utf8ToInt(letter) - utf8ToInt("a") + 1
+  if (stringr::str_detect(letter, "^[a-z]$")) {
+    return(utf8ToInt(letter) - utf8ToInt("a") + 1)
+  }
+  if (stringr::str_detect(letter, "^[A-Z]$")) {
+    return(utf8ToInt(letter) - utf8ToInt("A") + 27)
+  }
+  cli::cli_abort("Invalid WURCS residue ID: {.str {letter}}")
 }
 
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -617,6 +617,38 @@ test_that("parse_residue handles ambiguous u residues", {
 })
 
 
+test_that("parse_residue maps generic WURCS descriptors to generic monosaccharides", {
+  expect_equal(
+    parse_residue("axxxxh-1x_1-5"),
+    c(mono = "Hex", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("axxxxh-1b_1-5_2*NCC/3=O"),
+    c(mono = "HexNAc", anomer = "b1", sub = "")
+  )
+  expect_equal(
+    parse_residue("uxxxxm"),
+    c(mono = "dHex", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("u2112m"),
+    c(mono = "dHex", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("a4334m-1x_1-?"),
+    c(mono = "dHex", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("hxxxxh_2*NCC/3=O"),
+    c(mono = "HexNAc", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("AUd21122h_5*NCC/3=O"),
+    c(mono = "Neu5Ac", anomer = "??", sub = "")
+  )
+})
+
+
 test_that("parse_residue handles unknown ring closure", {
   expect_unknown_ring_residue <- function(residue, mono, sub = "") {
     expect_equal(
@@ -802,6 +834,17 @@ test_that("parse_residue handles unknown ring closure", {
       "2N"
     ),
     expect_unknown_ring_residue
+  )
+})
+
+
+test_that("letter_to_int handles uppercase WURCS residue IDs", {
+  expect_equal(letter_to_int("z"), 26)
+  expect_equal(letter_to_int("A"), 27)
+  expect_equal(letter_to_int("K"), 37)
+  expect_equal(
+    parse_one_linkage("a6-K1"),
+    list(from = 1, to = 37, linkage = "1-6")
   )
 })
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -635,6 +635,10 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
     c(mono = "dHex", anomer = "??", sub = "")
   )
   expect_equal(
+    parse_residue("a2112m-1x_1-5_2*NCC/3=O"),
+    c(mono = "dHexNAc", anomer = "?1", sub = "")
+  )
+  expect_equal(
     parse_residue("a4334m-1x_1-?"),
     c(mono = "dHex", anomer = "?1", sub = "")
   )
@@ -645,6 +649,10 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
   expect_equal(
     parse_residue("AUd21122h_5*NCC/3=O"),
     c(mono = "Neu5Ac", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("AUd21122h_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "Neu5Ac", anomer = "??", sub = "4Ac")
   )
 })
 


### PR DESCRIPTION
## Summary

Extend `parse_wurcs()` coverage for generic WURCS residue descriptors and large-structure linkage IDs.

## Background

The WURCS corpus in `docs/glycan_sequences_wurcs.csv` includes generic descriptors, ambiguous sialic descriptors, and residue IDs beyond lowercase `a-z`. The generated local audit artifacts remain ignored under `docs/`, but the audit was used to classify every sequence as parsed or recorded with a limitation reason.

## Details

- Map generic WURCS descriptors such as `axxxxh`, `uxxxxm`, and `hxxxxh_2*NCC/3=O` to supported generic `glyrepr` monosaccharides (`Hex`, `HexNAc`, `dHex`, etc.).
- Preserve `dHexNAc` for acetylated deoxyhexose fallback descriptors instead of normalizing them as `dHex` plus a `2NAc` substituent.
- Parse ambiguous `AUd21122h...` sialic descriptors as `Neu5Ac`, `Neu5Gc`, `Neu`, or `Kdn` where supported, including descriptors with earlier non-sialic substitutions.
- Decode uppercase WURCS residue IDs so linkages like `a6-K1` point to residues beyond index 26.
- Add regression tests for generic WURCS descriptors, substituted ambiguous sialic descriptors, acetylated deoxyhexose fallback descriptors, and uppercase residue IDs.
- Audited all 59,184 WURCS rows locally: 40,997 parsed; 18,187 were recorded with limitation reasons. Java fallback conversion was attempted for 18,007 rows missing a reference IUPAC string, with 2,450 fallback outputs recorded locally.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::load_all(quiet = TRUE); devtools::test(filter = "parse-wurcs")'` - 423 passed, 0 failed
- `Rscript -e 'devtools::test()'` - 935 passed, 0 failed
- `air format R/parse-wurcs.R tests/testthat/test-parse-wurcs.R`