### PR TITLE
Improve GlycoCT parser coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
 * `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
 * `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
+* `parse_glycoct()` now accepts space-separated GlycoCT records, such as records stored in CSV exports.
+* `parse_glycoct()` now supports generic GlycoCT `HEX`, N-acetylated `HEX`, deoxy-`HEX`, and sialic acid descriptors.
+* `parse_glycoct()` now maps direct GlycoCT `n-sulfate` substituents to N-sulfated amino sugars.
 * `parse_wurcs()` now parses WURCS alditol residues as regular reducing-end glycans with unknown anomer configurations. (#21)
 * `parse_glycoct()` now parses GlycoCT alditol residues as regular reducing-end glycans with unknown anomer configurations. (#22)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,9 @@
 * `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
 * `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
 * `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
-* `parse_glycoct()` now accepts space-separated GlycoCT records, such as records stored in CSV exports.
-* `parse_glycoct()` now supports generic GlycoCT `HEX`, N-acetylated `HEX`, deoxy-`HEX`, and sialic acid descriptors.
-* `parse_glycoct()` now maps direct GlycoCT `n-sulfate` substituents to N-sulfated amino sugars.
+* `parse_glycoct()` now accepts space-separated GlycoCT records, such as records stored in CSV exports. (#24)
+* `parse_glycoct()` now supports generic GlycoCT `HEX`, N-acetylated `HEX`, deoxy-`HEX`, and sialic acid descriptors. (#24)
+* `parse_glycoct()` now maps direct GlycoCT `n-sulfate` substituents to N-sulfated amino sugars. (#24)
 * `parse_wurcs()` now parses WURCS alditol residues as regular reducing-end glycans with unknown anomer configurations. (#21)
 * `parse_glycoct()` now parses GlycoCT alditol residues as regular reducing-end glycans with unknown anomer configurations. (#22)
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -37,10 +37,7 @@ parse_glycoct <- function(x, on_failure = "error") {
 }
 
 do_parse_glycoct <- function(x) {
-  # Split the input into lines
-  lines <- stringr::str_split(x, "\n")[[1]]
-  lines <- stringr::str_trim(lines)
-  lines <- lines[lines != ""]
+  lines <- split_glycoct_lines(x)
 
   # Find RES and LIN sections
   res_start <- which(lines == "RES")
@@ -75,6 +72,28 @@ do_parse_glycoct <- function(x) {
 
   # Build the graph
   build_glycoct_graph(residues, linkages)
+}
+
+#' Split a GlycoCT record into parser lines
+#'
+#' @param x A GlycoCT string.
+#'
+#' @return A character vector with section headers, residue lines, and linkage
+#'   lines as separate entries.
+#' @noRd
+split_glycoct_lines <- function(x) {
+  lines <- stringr::str_split(x, "\n")[[1]]
+  lines <- stringr::str_trim(lines)
+  lines <- lines[lines != ""]
+
+  if (
+    length(lines) == 1 &&
+      isTRUE(stringr::str_detect(lines, "^RES\\s+"))
+  ) {
+    return(stringr::str_split(lines, "\\s+")[[1]])
+  }
+
+  lines
 }
 
 parse_res_section <- function(res_lines) {
@@ -1080,6 +1099,11 @@ match_partial_composite_structure <- function(
   linkages,
   mono_mappings
 ) {
+  generic_result <- match_generic_glycoct_composite(group, residues, linkages)
+  if (!is.null(generic_result)) {
+    return(generic_result)
+  }
+
   # Try to find the best partial match and identify extra substituents
   best_match <- NULL
   best_extra_subs <- c()
@@ -1189,6 +1213,135 @@ match_partial_composite_structure <- function(
   }
 
   return(list(mono = "Unk", sub = ""))
+}
+
+#' Match generic GlycoCT monosaccharide composites
+#'
+#' @param group A vector of residue IDs in one composite group.
+#' @param residues A parsed GlycoCT residue list.
+#' @param linkages A parsed GlycoCT linkage list.
+#'
+#' @return A list with `mono` and `sub`, or `NULL` if no generic composite
+#'   matches.
+#' @noRd
+match_generic_glycoct_composite <- function(group, residues, linkages) {
+  group_mono <- NULL
+  group_subs <- c()
+
+  for (id in group) {
+    res <- residues[[as.character(id)]]
+    if (is.null(res)) {
+      next
+    }
+    if (res$type == "mono") {
+      group_mono <- res
+    } else if (res$type == "sub") {
+      group_subs <- c(group_subs, res$content)
+    }
+  }
+
+  if (is.null(group_mono)) {
+    return(NULL)
+  }
+
+  if (
+    "n-sulfate" %in%
+      group_subs &&
+      has_glycoct_substituent_at(group, residues, linkages, "n-sulfate", "2")
+  ) {
+    amino_mono <- map_glycoct_n_sulfate_mono(group_mono$content)
+    if (!is.na(amino_mono)) {
+      extra_subs <- group_subs[group_subs != "n-sulfate"]
+      extra_sub <- format_extra_substituents(
+        extra_subs,
+        group,
+        residues,
+        linkages
+      )
+      sub <- paste(c("2S", extra_sub[extra_sub != ""]), collapse = ",")
+      return(list(mono = amino_mono, sub = sub))
+    }
+  }
+
+  if (
+    is_generic_glycoct_hex(group_mono$content) &&
+      identical(group_subs, "n-acetyl") &&
+      has_glycoct_substituent_at(group, residues, linkages, "n-acetyl", "2")
+  ) {
+    mono <- if (is_generic_glycoct_dhex(group_mono$content)) {
+      "dHexNAc"
+    } else {
+      "HexNAc"
+    }
+
+    return(list(mono = mono, sub = ""))
+  }
+
+  if (
+    is_generic_glycoct_non(group_mono$content) &&
+      length(group_subs) == 1 &&
+      group_subs %in% c("n-acetyl", "n-glycolyl") &&
+      has_glycoct_substituent_at(group, residues, linkages, group_subs, "5")
+  ) {
+    mono <- dplyr::case_when(
+      group_subs == "n-acetyl" ~ "Neu5Ac",
+      group_subs == "n-glycolyl" ~ "Neu5Gc"
+    )
+
+    return(list(mono = mono, sub = ""))
+  }
+
+  NULL
+}
+
+#' Map a GlycoCT monosaccharide with direct N-sulfation to an amino sugar
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A monosaccharide name, or `NA` if unsupported.
+#' @noRd
+map_glycoct_n_sulfate_mono <- function(content) {
+  base_mono <- map_single_mono(content)
+  if (identical(base_mono, "Unk")) {
+    return(NA_character_)
+  }
+
+  if (identical(base_mono, "Hex")) {
+    return("HexN")
+  }
+
+  paste0(base_mono, "N")
+}
+
+#' Check whether a GlycoCT group contains a linked substituent
+#'
+#' @param group A vector of residue IDs in one composite group.
+#' @param residues A parsed GlycoCT residue list.
+#' @param linkages A parsed GlycoCT linkage list.
+#' @param substituent A substituent content string.
+#' @param position A monosaccharide position string.
+#'
+#' @return A logical scalar.
+#' @noRd
+has_glycoct_substituent_at <- function(
+  group,
+  residues,
+  linkages,
+  substituent,
+  position
+) {
+  any(purrr::map_lgl(linkages, function(linkage) {
+    from_res <- residues[[as.character(linkage$from_res)]]
+    to_res <- residues[[as.character(linkage$to_res)]]
+    !is.null(from_res) &&
+      !is.null(to_res) &&
+      linkage$from_res %in% group &&
+      linkage$to_res %in% group &&
+      identical(from_res$type, "mono") &&
+      identical(to_res$type, "sub") &&
+      identical(to_res$content, substituent) &&
+      identical(linkage$from_pos, position)
+  }))
 }
 
 format_extra_substituents <- function(extra_subs, group, residues, linkages) {
@@ -1356,6 +1509,13 @@ map_single_mono <- function(content) {
     return("Unk")
   }
 
+  if (is_generic_glycoct_dhex(content)) {
+    return("dHex")
+  }
+  if (is_generic_glycoct_hex(content)) {
+    return("Hex")
+  }
+
   # If no exact match, fall back to basic parsing
   parts <- stringr::str_split(content, "-")[[1]]
   if (length(parts) >= 2) {
@@ -1406,6 +1566,42 @@ map_single_mono <- function(content) {
   }
 
   return("Unk")
+}
+
+#' Check whether a GlycoCT content string is a generic hexose
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_generic_glycoct_hex <- function(content) {
+  isTRUE(stringr::str_detect(
+    content,
+    "^HEX-(?:\\d+|x):(?:\\d+|x)(?:\\|6:d)?$"
+  ))
+}
+
+#' Check whether a GlycoCT content string is a generic deoxyhexose
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_generic_glycoct_dhex <- function(content) {
+  isTRUE(stringr::str_detect(
+    content,
+    "^HEX-(?:\\d+|x):(?:\\d+|x)\\|6:d$"
+  ))
+}
+
+#' Check whether a GlycoCT content string is a generic sialic acid backbone
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_generic_glycoct_non <- function(content) {
+  isTRUE(identical(content, "NON-2:6|1:a|2:keto|3:d"))
 }
 
 find_group_containing <- function(groups, res_id) {

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -1265,7 +1265,7 @@ match_generic_glycoct_composite <- function(group, residues, linkages) {
 
   if (
     is_generic_glycoct_hex(group_mono$content) &&
-      identical(group_subs, "n-acetyl") &&
+      "n-acetyl" %in% group_subs &&
       has_glycoct_substituent_at(group, residues, linkages, "n-acetyl", "2")
   ) {
     mono <- if (is_generic_glycoct_dhex(group_mono$content)) {
@@ -1273,25 +1273,87 @@ match_generic_glycoct_composite <- function(group, residues, linkages) {
     } else {
       "HexNAc"
     }
-
-    return(list(mono = mono, sub = ""))
-  }
-
-  if (
-    is_generic_glycoct_non(group_mono$content) &&
-      length(group_subs) == 1 &&
-      group_subs %in% c("n-acetyl", "n-glycolyl") &&
-      has_glycoct_substituent_at(group, residues, linkages, group_subs, "5")
-  ) {
-    mono <- dplyr::case_when(
-      group_subs == "n-acetyl" ~ "Neu5Ac",
-      group_subs == "n-glycolyl" ~ "Neu5Gc"
+    extra_subs <- group_subs[group_subs != "n-acetyl"]
+    extra_sub <- format_extra_substituents(
+      extra_subs,
+      group,
+      residues,
+      linkages
     )
 
-    return(list(mono = mono, sub = ""))
+    return(list(mono = mono, sub = extra_sub))
+  }
+
+  sialic_identity_sub <- find_generic_glycoct_sialic_identity_sub(
+    group,
+    residues,
+    linkages,
+    group_mono$content,
+    group_subs
+  )
+  if (!is.na(sialic_identity_sub)) {
+    mono <- dplyr::case_when(
+      sialic_identity_sub == "n-acetyl" ~ "Neu5Ac",
+      sialic_identity_sub == "n-glycolyl" ~ "Neu5Gc"
+    )
+    extra_subs <- group_subs[group_subs != sialic_identity_sub]
+    extra_sub <- format_extra_substituents(
+      extra_subs,
+      group,
+      residues,
+      linkages
+    )
+
+    return(list(mono = mono, sub = extra_sub))
   }
 
   NULL
+}
+
+#' Find the identity-defining substituent for generic GlycoCT sialic acids
+#'
+#' @param group A vector of residue IDs in one composite group.
+#' @param residues A parsed GlycoCT residue list.
+#' @param linkages A parsed GlycoCT linkage list.
+#' @param mono_content GlycoCT monosaccharide content without the leading
+#'   anomer.
+#' @param group_subs Substituent content strings in the group.
+#'
+#' @return A character scalar with the identity-defining substituent, or `NA`
+#'   when the group is not a supported generic sialic acid.
+#' @noRd
+find_generic_glycoct_sialic_identity_sub <- function(
+  group,
+  residues,
+  linkages,
+  mono_content,
+  group_subs
+) {
+  if (!is_generic_glycoct_non(mono_content)) {
+    return(NA_character_)
+  }
+
+  candidate_subs <- c("n-acetyl", "n-glycolyl")
+  matched_subs <- candidate_subs[
+    candidate_subs %in%
+      group_subs &
+      purrr::map_lgl(
+        candidate_subs,
+        ~ has_glycoct_substituent_at(
+          group,
+          residues,
+          linkages,
+          .x,
+          "5"
+        )
+      )
+  ]
+
+  if (length(matched_subs) != 1) {
+    return(NA_character_)
+  }
+
+  matched_subs
 }
 
 #' Map a GlycoCT monosaccharide with direct N-sulfation to an amino sugar

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -13,6 +13,76 @@ test_that("GlycoCT: Gal(b1-3)GalNAc(a1-", {
   expect_equal(result, expected)
 })
 
+test_that("GlycoCT accepts space-separated records", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2s:n-acetyl",
+    "3b:b-dgal-HEX-1:5",
+    "LIN",
+    "1:1d(2+1)2n",
+    "2:1o(3+1)3d"
+  )
+
+  result <- as.character(parse_glycoct(glycoct))
+
+  expect_equal(result, "Gal(b1-3)GalNAc(a1-")
+})
+
+test_that("GlycoCT maps generic HEX descriptors", {
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-x:x")), "Hex(??-")
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-1:x|6:d")), "dHex(?1-")
+
+  hexnac <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
+  )
+  expect_equal(as.character(parse_glycoct(hexnac)), "HexNAc(?1-")
+})
+
+test_that("GlycoCT maps generic Neu5Ac descriptors", {
+  neu5ac <- paste0(
+    "RES\n",
+    "1b:x-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(5+1)2n"
+  )
+  neu5gc <- paste0(
+    "RES\n",
+    "1b:x-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:n-glycolyl\n",
+    "LIN\n",
+    "1:1d(5+1)2n"
+  )
+
+  expect_equal(as.character(parse_glycoct(neu5ac)), "Neu5Ac(?2-")
+  expect_equal(as.character(parse_glycoct(neu5gc)), "Neu5Gc(?2-")
+})
+
+test_that("GlycoCT maps direct n-sulfate substituents", {
+  glcns <- paste0(
+    "RES\n",
+    "1b:x-dglc-HEX-1:5\n",
+    "2s:n-sulfate\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
+  )
+  hexns <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:n-sulfate\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
+  )
+
+  expect_equal(as.character(parse_glycoct(glcns)), "GlcN2S(?1-")
+  expect_equal(as.character(parse_glycoct(hexns)), "HexN2S(?1-")
+})
+
 test_that("GlycoCT: Neu5Ac(a2-3)Gal(b1-3)[Neu5Ac(a2-6)]GalNAc(a1-", {
   glycoct <- paste0(
     "RES\n",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -40,7 +40,17 @@ test_that("GlycoCT maps generic HEX descriptors", {
     "LIN\n",
     "1:1d(2+1)2n"
   )
+  hexnac_6s <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:n-acetyl\n",
+    "3s:sulfate\n",
+    "LIN\n",
+    "1:1d(2+1)2n\n",
+    "2:1o(6+1)3n"
+  )
   expect_equal(as.character(parse_glycoct(hexnac)), "HexNAc(?1-")
+  expect_equal(as.character(parse_glycoct(hexnac_6s)), "HexNAc6S(?1-")
 })
 
 test_that("GlycoCT maps generic Neu5Ac descriptors", {
@@ -58,9 +68,29 @@ test_that("GlycoCT maps generic Neu5Ac descriptors", {
     "LIN\n",
     "1:1d(5+1)2n"
   )
+  neu5ac_9ac <- paste0(
+    "RES\n",
+    "1b:x-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:n-acetyl\n",
+    "3s:acetyl\n",
+    "LIN\n",
+    "1:1d(5+1)2n\n",
+    "2:1o(9+1)3n"
+  )
+  neu5gc_9s <- paste0(
+    "RES\n",
+    "1b:x-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:n-glycolyl\n",
+    "3s:sulfate\n",
+    "LIN\n",
+    "1:1d(5+1)2n\n",
+    "2:1o(9+1)3n"
+  )
 
   expect_equal(as.character(parse_glycoct(neu5ac)), "Neu5Ac(?2-")
   expect_equal(as.character(parse_glycoct(neu5gc)), "Neu5Gc(?2-")
+  expect_equal(as.character(parse_glycoct(neu5ac_9ac)), "Neu5Ac9Ac(?2-")
+  expect_equal(as.character(parse_glycoct(neu5gc_9s)), "Neu5Gc9S(?2-")
 })
 
 test_that("GlycoCT maps direct n-sulfate substituents", {


### PR DESCRIPTION
## Summary

Improve `parse_glycoct()` coverage for GlycoCT records from the sequence corpus.

## Details

- Accept space-separated GlycoCT records, including CSV-export style records where `RES`, residues, `LIN`, and linkages are stored on one line.
- Map representable generic GlycoCT descriptors to `glyrepr` monosaccharides, including generic `HEX`, N-acetylated `HEX`, deoxy-`HEX`, and generic Neu5Ac/Neu5Gc descriptors.
- Map direct GlycoCT `n-sulfate` substituents to N-sulfated amino sugars.
- Add focused regression coverage for the newly supported parser cases.
- Update `NEWS.md` with the live `(#24)` suffix for the GlycoCT entries.

## Verification

- `git rebase main`
- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::load_all(quiet = TRUE); devtools::test(filter = "parse-glycoct")'` -> 306 passed
- `Rscript -e 'devtools::test()'` -> 943 passed
- `air format R/parse-glycoct.R tests/testthat/test-parse-glycoct.R`
- `git diff --check main..HEAD`