### PR TITLE
feat: make auto_parse support GlyCAM IUPAC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## Minor improvements and bug fixes
 
+* `auto_parse()` now detects GlyCAM IUPAC structures and routes them to `parse_glycam_iupac()`. (#26)
 * `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
 * `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
 * `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
@@ -185,4 +186,3 @@
 * `parse_iupac_short()`, `parse_iupac_extended()`, `parse_iupac_condensed()`,
   `parse_wurcs()` now support multiple substituents on the same monosaccharide,
   to align with the updates in `glyrepr` v0.5.0.
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,10 @@
 ## New features
 
 * Add `parse_glycam_iupac()` to parse GlyCAM IUPAC structures. (#25)
+* `auto_parse()` now detects GlyCAM IUPAC structures and routes them to `parse_glycam_iupac()`. (#26)
 
 ## Minor improvements and bug fixes
 
-* `auto_parse()` now detects GlyCAM IUPAC structures and routes them to `parse_glycam_iupac()`. (#26)
 * `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
 * `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
 * `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
@@ -156,6 +156,7 @@
   ```
 
   Now:
+
   ```r
   > parse_iupac_condensed("bad_glycan")
   ```
@@ -186,3 +187,4 @@
 * `parse_iupac_short()`, `parse_iupac_extended()`, `parse_iupac_condensed()`,
   `parse_wurcs()` now support multiple substituents on the same monosaccharide,
   to align with the updates in `glyrepr` v0.5.0.
+

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -10,10 +10,11 @@
 #' 2. IUPAC-condensed
 #' 3. IUPAC-extended
 #' 4. IUPAC-short
-#' 5. WURCS
-#' 6. Linear Code
-#' 7. pGlyco
-#' 8. StrucGP
+#' 5. GlyCAM IUPAC
+#' 6. WURCS
+#' 7. Linear Code
+#' 8. pGlyco
+#' 9. StrucGP
 #'
 #' @param x A character vector of structure strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
@@ -52,6 +53,8 @@ choose_parser <- function(x) {
     return(do_parse_pglyco_struc)
   } else if (stringr::str_starts(x, "A") && stringr::str_ends(x, "a")) {
     return(do_parse_strucgp_struc)
+  } else if (stringr::str_ends(x, "-OH")) {
+    return(do_parse_glycam_iupac)
   } else if (
     stringr::str_detect(x, "\\u2192") || # Unicode arrow →
       stringr::str_detect(x, "->") || # Plain text arrow ->

--- a/man/auto_parse.Rd
+++ b/man/auto_parse.Rd
@@ -26,6 +26,7 @@ Supported types:
 \item IUPAC-condensed
 \item IUPAC-extended
 \item IUPAC-short
+\item GlyCAM IUPAC
 \item WURCS
 \item Linear Code
 \item pGlyco

--- a/tests/testthat/test-auto-parse.R
+++ b/tests/testthat/test-auto-parse.R
@@ -47,6 +47,13 @@ test_that("auto_parse correctly identifies and parses Linear Code format", {
   expect_equal(as.character(result), as.character(expected))
 })
 
+test_that("auto_parse correctly identifies and parses GlyCAM IUPAC format", {
+  input <- "DManpa1-3[DManpa1-6]DManpb1-4DGlcpNAcb1-4DGlcpNAcb1-OH"
+  result <- auto_parse(input)
+  expected <- parse_glycam_iupac(input)
+  expect_equal(as.character(result), as.character(expected))
+})
+
 test_that("auto_parse works with mixed format vector", {
   mixed_input <- c(
     "Gal(b1-3)GlcNAc(b1-4)Glc(a1-", # IUPAC-condensed


### PR DESCRIPTION
## Summary

Teach `auto_parse()` to detect GlyCAM IUPAC strings and route them through `parse_glycam_iupac()`.

## Details

- Adds `-OH` suffix detection to `choose_parser()` so GlyCAM IUPAC inputs use `do_parse_glycam_iupac()`.
- Updates the `auto_parse()` supported-types documentation to list GlyCAM IUPAC.
- Adds an `auto_parse()` regression that compares GlyCAM IUPAC dispatch against `parse_glycam_iupac()` directly.
- Adds the `NEWS.md` entry for this user-visible dispatch improvement with the live PR number.

## Verification

- `Rscript -e 'devtools::document()'`
- `air format R/auto-parse.R tests/testthat/test-auto-parse.R`
- `Rscript -e 'devtools::test(filter = "auto-parse")'` -> 9 passed
- `Rscript -e 'devtools::test()'` -> 954 passed
- `git diff --check`