### PR TITLE
fix: expand GlyCAM parser coverage for names and modifiers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## Minor improvements and bug fixes
 
+* `parse_glycam_iupac()` now recognizes more GlyCAM monosaccharide labels, generic `Hex`, unknown modifier positions, and unknown linkage positions. (#27)
 * `parse_wurcs()` now supports additional generic WURCS residue descriptors. (#23)
 * `parse_wurcs()` now supports ambiguous WURCS sialic acid descriptors. (#23)
 * `parse_wurcs()` now supports uppercase WURCS residue IDs for large structures. (#23)
@@ -187,4 +188,3 @@
 * `parse_iupac_short()`, `parse_iupac_extended()`, `parse_iupac_condensed()`,
   `parse_wurcs()` now support multiple substituents on the same monosaccharide,
   to align with the updates in `glyrepr` v0.5.0.
-

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -89,7 +89,7 @@ convert_glycam_iupac_token <- function(token) {
   modifiers <- convert_glycam_iupac_modifiers(
     stringr::str_extract_all(
       token,
-      "\\[[0-9][A-Za-z]+(?:,[0-9][A-Za-z]+)*\\]"
+      glycam_iupac_modifier_pattern()
     )[[1]]
   )
   anomer <- residue_match[1, 3]
@@ -110,12 +110,23 @@ convert_glycam_iupac_token <- function(token) {
 #' @noRd
 glycam_iupac_residue_pattern <- function() {
   paste0(
-    "([DL][A-Za-z0-9]+?)",
-    "(?:\\[[0-9][A-Za-z]+(?:,[0-9][A-Za-z]+)*\\])*",
+    "([A-Za-z0-9]+?)",
+    "(?:",
+    glycam_iupac_modifier_pattern(),
+    ")*",
     "([ab\\?])",
     "([0-9\\?])-",
     "([0-9\\?]|[A-Za-z][A-Za-z0-9]*)"
   )
+}
+
+
+#' Create the GlyCAM IUPAC modifier regex
+#'
+#' @return A regex pattern for one bracketed GlyCAM modifier group.
+#' @noRd
+glycam_iupac_modifier_pattern <- function() {
+  "\\[[0-9\\?][A-Za-z]+(?:,[0-9\\?][A-Za-z]+)*\\]"
 }
 
 
@@ -137,27 +148,7 @@ is_glycam_iupac_reducing_end_moiety <- function(x) {
 #' @return A glyrepr monosaccharide name.
 #' @noRd
 convert_glycam_iupac_mono <- function(mono) {
-  mono_map <- c(
-    DFucp = "Fuc",
-    DGalp = "Gal",
-    DGalpNAc = "GalNAc",
-    DGlcp = "Glc",
-    DGlcpA = "GlcA",
-    DGlcpNAc = "GlcNAc",
-    DKDNp = "Kdn",
-    DManp = "Man",
-    DManpNAc = "ManNAc",
-    DNeup5Ac = "Neu5Ac",
-    DNeup5Gc = "Neu5Gc",
-    DRibp = "Rib",
-    DXylf = "Xyl",
-    DXylp = "Xyl",
-    LArap = "Ara",
-    LFucp = "Fuc",
-    LGulp = "Gul",
-    LIdopA = "IdoA",
-    LRhap = "Rha"
-  )
+  mono_map <- glycam_iupac_mono_map()
 
   converted <- unname(mono_map[[mono]])
   if (is.null(converted)) {
@@ -165,6 +156,97 @@ convert_glycam_iupac_mono <- function(mono) {
   }
 
   converted
+}
+
+
+#' Map GlyCAM monosaccharide labels to glyrepr monosaccharide labels
+#'
+#' @return A named character vector mapping GlyCAM labels to glyrepr labels.
+#' @noRd
+glycam_iupac_mono_map <- function() {
+  c(
+    Hexp = "Hex",
+    DFucp = "Fuc",
+    DGalp = "Gal",
+    DGalpA = "GalA",
+    DGalpN = "GalN",
+    DGalpNAc = "GalNAc",
+    DGlcp = "Glc",
+    DGlcpA = "GlcA",
+    DGlcpN = "GlcN",
+    DGlcpNAc = "GlcNAc",
+    DGulp = "Gul",
+    DGulpA = "GulA",
+    DGulpN = "GulN",
+    DGulpNAc = "GulNAc",
+    DManp = "Man",
+    DManpA = "ManA",
+    DManpN = "ManN",
+    DManpNAc = "ManNAc",
+    DAllp = "All",
+    DAllpA = "AllA",
+    DAllpN = "AllN",
+    DAllpNAc = "AllNAc",
+    DTalp = "Tal",
+    DTalpA = "TalA",
+    DTalpN = "TalN",
+    DTalpNAc = "TalNAc",
+    LAltp = "Alt",
+    LAltpA = "AltA",
+    LAltpN = "AltN",
+    LAltpNAc = "AltNAc",
+    LIdop = "Ido",
+    LIdopA = "IdoA",
+    LIdopN = "IdoN",
+    LIdopNAc = "IdoNAc",
+    DQuip = "Qui",
+    DQuipNAc = "QuiNAc",
+    D6dGulp = "6dGul",
+    D6dTalp = "6dTal",
+    L6dAltp = "6dAlt",
+    L6dAltpNAc = "6dAltNAc",
+    D6dTalpNAc = "6dTalNAc",
+    LFucp = "Fuc",
+    LFucpNAc = "FucNAc",
+    LRhap = "Rha",
+    LRhapNAc = "RhaNAc",
+    DOlip = "Oli",
+    DTyvp = "Tyv",
+    DAbep = "Abe",
+    DParp = "Par",
+    DDigp = "Dig",
+    LColp = "Col",
+    LArap = "Ara",
+    LLyxp = "Lyx",
+    DRibp = "Rib",
+    DXylf = "Xyl",
+    DXylp = "Xyl",
+    DNeup5Ac = "Neu5Ac",
+    DNeup5Gc = "Neu5Gc",
+    Neup = "Neu",
+    Neup5Ac = "Neu5Ac",
+    Neup5Gc = "Neu5Gc",
+    DKDNp = "Kdn",
+    Kdnp = "Kdn",
+    Psep = "Pse",
+    Legp = "Leg",
+    Acip = "Aci",
+    `4eLegp` = "4eLeg",
+    DBacp = "Bac",
+    LDmanHepp = "LDmanHep",
+    DKdop = "Kdo",
+    DDhap = "Dha",
+    DDmanHepp = "DDmanHep",
+    DMurp = "Mur",
+    DMurpNAc = "MurNAc",
+    DMurpNGc = "MurNGc",
+    DApif = "Api",
+    DApip = "Api",
+    DFrup = "Fru",
+    DTagp = "Tag",
+    LSorp = "Sor",
+    DPsip = "Psi"
+  )
 }
 
 

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -21,12 +21,169 @@ test_that("GlyCAM IUPAC converts simple and branched glycans", {
   )
 })
 
+test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
+  skip_on_old_win()
+
+  to_parse <- c(
+    Hex = "Hexpb1-OH",
+    Glc = "DGlcpb1-OH",
+    Man = "DManpb1-OH",
+    Gal = "DGalpb1-OH",
+    Gul = "DGulpb1-OH",
+    Alt = "LAltpb1-OH",
+    All = "DAllpb1-OH",
+    Tal = "DTalpb1-OH",
+    Ido = "LIdopb1-OH",
+    GlcNAc = "DGlcpNAcb1-OH",
+    GalNAc = "DGalpNAcb1-OH",
+    ManNAc = "DManpNAcb1-OH",
+    GulNAc = "DGulpNAcb1-OH",
+    AltNAc = "LAltpNAcb1-OH",
+    AllNAc = "DAllpNAcb1-OH",
+    TalNAc = "DTalpNAcb1-OH",
+    IdoNAc = "LIdopNAcb1-OH",
+    GlcN = "DGlcpNb1-OH",
+    ManN = "DManpNb1-OH",
+    GalN = "DGalpNb1-OH",
+    GulN = "DGulpNb1-OH",
+    AltN = "LAltpNb1-OH",
+    AllN = "DAllpNb1-OH",
+    TalN = "DTalpNb1-OH",
+    IdoN = "LIdopNb1-OH",
+    GlcA = "DGlcpAb1-OH",
+    ManA = "DManpAb1-OH",
+    GalA = "DGalpAb1-OH",
+    GulA = "DGulpAb1-OH",
+    AltA = "LAltpAb1-OH",
+    AllA = "DAllpAb1-OH",
+    TalA = "DTalpAb1-OH",
+    IdoA = "LIdopAb1-OH",
+    Fuc = "LFucpb1-OH",
+    Qui = "DQuipb1-OH",
+    Rha = "LRhapb1-OH",
+    QuiNAc = "DQuipNAcb1-OH",
+    RhaNAc = "LRhapNAcb1-OH",
+    FucNAc = "LFucpNAcb1-OH",
+    Oli = "DOlipb1-OH",
+    Tyv = "DTyvpb1-OH",
+    Abe = "DAbepb1-OH",
+    Par = "DParpb1-OH",
+    Dig = "DDigpb1-OH",
+    Col = "LColpb1-OH",
+    Ara = "LArapb1-OH",
+    Lyx = "LLyxpb1-OH",
+    Xyl = "DXylpb1-OH",
+    Rib = "DRibpb1-OH",
+    Neu5Ac = "DNeup5Acb2-OH",
+    Neu5Gc = "DNeup5Gcb2-OH",
+    Neu = "Neupb2-OH",
+    Kdn = "DKDNpb2-OH",
+    Pse = "Psepb2-OH",
+    Leg = "Legpb2-OH",
+    Aci = "Acipb2-OH",
+    Bac = "DBacpb1-OH",
+    LDmanHep = "LDmanHeppb1-OH",
+    Kdo = "DKdopb2-OH",
+    Dha = "DDhapb2-OH",
+    DDmanHep = "DDmanHeppb1-OH",
+    MurNAc = "DMurpNAcb1-OH",
+    MurNGc = "DMurpNGcb1-OH",
+    Mur = "DMurpb1-OH",
+    Api = "DApifb1-OH",
+    Fru = "DFrupb2-OH",
+    Tag = "DTagpb2-OH",
+    Sor = "LSorpb2-OH",
+    Psi = "DPsipb2-OH"
+  )
+
+  parsed <- parse_glycam_iupac(to_parse)
+
+  expect_identical(
+    as.character(parsed),
+    c(
+      Hex = "Hex(b1-",
+      Glc = "Glc(b1-",
+      Man = "Man(b1-",
+      Gal = "Gal(b1-",
+      Gul = "Gul(b1-",
+      Alt = "Alt(b1-",
+      All = "All(b1-",
+      Tal = "Tal(b1-",
+      Ido = "Ido(b1-",
+      GlcNAc = "GlcNAc(b1-",
+      GalNAc = "GalNAc(b1-",
+      ManNAc = "ManNAc(b1-",
+      GulNAc = "GulNAc(b1-",
+      AltNAc = "AltNAc(b1-",
+      AllNAc = "AllNAc(b1-",
+      TalNAc = "TalNAc(b1-",
+      IdoNAc = "IdoNAc(b1-",
+      GlcN = "GlcN(b1-",
+      ManN = "ManN(b1-",
+      GalN = "GalN(b1-",
+      GulN = "GulN(b1-",
+      AltN = "AltN(b1-",
+      AllN = "AllN(b1-",
+      TalN = "TalN(b1-",
+      IdoN = "IdoN(b1-",
+      GlcA = "GlcA(b1-",
+      ManA = "ManA(b1-",
+      GalA = "GalA(b1-",
+      GulA = "GulA(b1-",
+      AltA = "AltA(b1-",
+      AllA = "AllA(b1-",
+      TalA = "TalA(b1-",
+      IdoA = "IdoA(b1-",
+      Fuc = "Fuc(b1-",
+      Qui = "Qui(b1-",
+      Rha = "Rha(b1-",
+      QuiNAc = "QuiNAc(b1-",
+      RhaNAc = "RhaNAc(b1-",
+      FucNAc = "FucNAc(b1-",
+      Oli = "Oli(b1-",
+      Tyv = "Tyv(b1-",
+      Abe = "Abe(b1-",
+      Par = "Par(b1-",
+      Dig = "Dig(b1-",
+      Col = "Col(b1-",
+      Ara = "Ara(b1-",
+      Lyx = "Lyx(b1-",
+      Xyl = "Xyl(b1-",
+      Rib = "Rib(b1-",
+      Neu5Ac = "Neu5Ac(b2-",
+      Neu5Gc = "Neu5Gc(b2-",
+      Neu = "Neu(b2-",
+      Kdn = "Kdn(b2-",
+      Pse = "Pse(b2-",
+      Leg = "Leg(b2-",
+      Aci = "Aci(b2-",
+      Bac = "Bac(b1-",
+      LDmanHep = "LDmanHep(b1-",
+      Kdo = "Kdo(b2-",
+      Dha = "Dha(b2-",
+      DDmanHep = "DDmanHep(b1-",
+      MurNAc = "MurNAc(b1-",
+      MurNGc = "MurNGc(b1-",
+      Mur = "Mur(b1-",
+      Api = "Api(b1-",
+      Fru = "Fru(b2-",
+      Tag = "Tag(b2-",
+      Sor = "Sor(b2-",
+      Psi = "Psi(b2-"
+    )
+  )
+})
+
 test_that("GlyCAM IUPAC converts residue modifiers", {
   skip_on_old_win()
 
   to_parse <- c(
     sulfate = "DNeup5Aca2-3DGalp[6S]b1-4[LFucpa1-3]DGlcpNAc[6S]b1-OH",
-    acetate = "DNeup5Ac[9A]a2-6DGalpb1-4DGlcpNAcb1-OH"
+    acetate = "DNeup5Ac[9A]a2-6DGalpb1-4DGlcpNAcb1-OH",
+    methyl = "DGlcp[3Me]b1-OH",
+    phosphate = "DGlcp[6P]b1-OH",
+    amino = "DGlcp[2N]b1-OH",
+    unknown_position = "DGalp[?S]b1-OH"
   )
 
   parsed <- parse_glycam_iupac(to_parse)
@@ -35,7 +192,38 @@ test_that("GlyCAM IUPAC converts residue modifiers", {
     as.character(parsed),
     c(
       sulfate = "Neu5Ac(a2-3)Gal6S(b1-4)[Fuc(a1-3)]GlcNAc6S(b1-",
-      acetate = "Neu5Ac9Ac(a2-6)Gal(b1-4)GlcNAc(b1-"
+      acetate = "Neu5Ac9Ac(a2-6)Gal(b1-4)GlcNAc(b1-",
+      methyl = "Glc3Me(b1-",
+      phosphate = "Glc6P(b1-",
+      amino = "Glc2N(b1-",
+      unknown_position = "Gal?S(b1-"
+    )
+  )
+})
+
+test_that("GlyCAM IUPAC converts anomers and unknown linkage positions", {
+  skip_on_old_win()
+
+  to_parse <- c(
+    alpha = "DGalpa1-4DGlcpb1-OH",
+    beta = "DGalpb1-4DGlcpb1-OH",
+    unknown_anomer = "DGalp?1-4DGlcpb1-OH",
+    unknown_child_position = "DGalpa?-4DGlcpb1-OH",
+    unknown_parent_position = "DGalpa1-?DGlcpb1-OH",
+    unknown_both_linkage_positions = "DGalp?1-?DGlcpb1-OH"
+  )
+
+  parsed <- parse_glycam_iupac(to_parse)
+
+  expect_identical(
+    as.character(parsed),
+    c(
+      alpha = "Gal(a1-4)Glc(b1-",
+      beta = "Gal(b1-4)Glc(b1-",
+      unknown_anomer = "Gal(?1-4)Glc(b1-",
+      unknown_child_position = "Gal(a?-4)Glc(b1-",
+      unknown_parent_position = "Gal(a1-?)Glc(b1-",
+      unknown_both_linkage_positions = "Gal(?1-?)Glc(b1-"
     )
   )
 })


### PR DESCRIPTION
## Summary
Expand GlyCAM IUPAC parser coverage for monosaccharide names, modifiers, and unknown linkage notation.

## Background
`tests/testthat/checklist.R` calls out parser coverage for monosaccharide names, generic monosaccharides, substituents, anomers, linkage positions, single-residue glycans, and complex examples. The existing GlyCAM tests covered representative corpus cases but missed much of that checklist matrix.

## Details
- Expand `test-parse-glycam-iupac.R` with direct IUPAC-condensed expectations for checklist-backed monosaccharides, generic `Hex`, supported substituents, unknown modifier positions, anomers, and unknown linkage positions.
- Broaden GlyCAM residue tokenization so labels are not limited to `D`/`L` prefixes and modifier positions can be `?`.
- Add a shared modifier regex and a larger GlyCAM monosaccharide map for the labels that can be represented through the delegated IUPAC-condensed parser.
- Add a `NEWS.md` entry for the parser coverage expansion. (#27)

## Verification
- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "parse-glycam-iupac")'` -> 9 passed
- `Rscript -e 'devtools::test()'` -> 956 passed