### PR TITLE
feat: add parser progress bars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     dplyr,
     glyrepr (>= 0.12.0),
     igraph,
-    purrr,
+    purrr (>= 1.0.0),
     rlang,
     rstackdeque,
     stringr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## New features
 
+* Add a `progress` argument to parser functions for opt-in progress bars while parsing. (#29)
 * Add `parse_iupac_compact()` to parse IUPAC-compact structures. (#28)
 * Add `parse_glycam_iupac()` to parse GlyCAM IUPAC structures. (#25, #27)
 * `auto_parse()` now detects GlyCAM IUPAC structures and routes them to `parse_glycam_iupac()`. (#26)

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -20,6 +20,7 @@
 #' @param x A character vector of structure strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -36,8 +37,13 @@
 #' auto_parse(x)
 #'
 #' @export
-auto_parse <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_auto_parse, on_failure = on_failure)
+auto_parse <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_auto_parse,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 do_auto_parse <- function(x) {
@@ -50,7 +56,7 @@ choose_parser <- function(x) {
     return(do_parse_glycoct)
   } else if (stringr::str_detect(x, "WURCS")) {
     return(do_parse_wurcs)
-  } else if (stringr::str_starts(x,"\\([HNAGFSap]")) {
+  } else if (stringr::str_starts(x, "\\([HNAGFSap]")) {
     return(do_parse_pglyco_struc)
   } else if (stringr::str_starts(x, "A") && stringr::str_ends(x, "a")) {
     return(do_parse_strucgp_struc)

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -19,6 +19,7 @@
 #'   and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -29,8 +30,13 @@
 #' @seealso [parse_iupac_condensed()]
 #'
 #' @export
-parse_glycam_iupac <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_glycam_iupac, on_failure = on_failure)
+parse_glycam_iupac <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_glycam_iupac,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -16,6 +16,7 @@
 #' @param x A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -32,8 +33,13 @@
 #' parse_glycoct(glycoct)
 #'
 #' @export
-parse_glycoct <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_glycoct, on_failure = on_failure)
+parse_glycoct <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_glycoct,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 do_parse_glycoct <- function(x) {

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -16,6 +16,7 @@
 #'   and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -26,8 +27,13 @@
 #' @seealso [parse_iupac_condensed()]
 #'
 #' @export
-parse_iupac_compact <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_iupac_compact, on_failure = on_failure)
+parse_iupac_compact <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_iupac_compact,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-iupac-condensed.R
+++ b/R/parse-iupac-condensed.R
@@ -24,6 +24,7 @@
 #' @param x A character vector of IUPAC-condensed strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -34,8 +35,13 @@
 #' @seealso [parse_iupac_short()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_condensed <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_iupac_condensed, on_failure = on_failure)
+parse_iupac_condensed <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_iupac_condensed,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 do_parse_iupac_condensed <- function(x) {

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -6,6 +6,7 @@
 #' @param x A character vector of IUPAC-extended strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @details
 #' The function accepts both a Unicode format (using the Greek letters alpha/beta
@@ -24,8 +25,13 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_short()]
 #'
 #' @export
-parse_iupac_extended <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_iupac_extended, on_failure = on_failure)
+parse_iupac_extended <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_iupac_extended,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-iupac-short.R
+++ b/R/parse-iupac-short.R
@@ -17,6 +17,7 @@
 #' @param x A character vector of IUPAC-short strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -27,8 +28,13 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_short <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_iupac_short, on_failure = on_failure)
+parse_iupac_short <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_iupac_short,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -6,6 +6,7 @@
 #' @param x A character vector of Linear Code strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -14,8 +15,13 @@
 #' parse_linear_code(linear_code)
 #'
 #' @export
-parse_linear_code <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_linear_code, on_failure = on_failure)
+parse_linear_code <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_linear_code,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 do_parse_linear_code <- function(x) {

--- a/R/parse-pglyco.R
+++ b/R/parse-pglyco.R
@@ -6,6 +6,7 @@
 #' @param x A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -14,8 +15,13 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_pglyco_struc <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_pglyco_struc, on_failure = on_failure)
+parse_pglyco_struc <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_pglyco_struc,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-strucgp.R
+++ b/R/parse-strucgp.R
@@ -6,6 +6,7 @@
 #' @param x A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -14,8 +15,13 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_strucgp_struc <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_strucgp_struc, on_failure = on_failure)
+parse_strucgp_struc <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_strucgp_struc,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -9,6 +9,7 @@
 #' @param x A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -21,8 +22,13 @@
 #' parse_wurcs(wurcs)
 #'
 #' @export
-parse_wurcs <- function(x, on_failure = "error") {
-  struc_parser_wrapper(x, do_parse_wurcs, on_failure = on_failure)
+parse_wurcs <- function(x, on_failure = "error", progress = FALSE) {
+  struc_parser_wrapper(
+    x,
+    do_parse_wurcs,
+    on_failure = on_failure,
+    progress = progress
+  )
 }
 
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -4,6 +4,7 @@
 #' @param parser A parser function that returns one glycan graph per string.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
+#' @param progress Whether to show a progress bar while parsing.
 #' @param call The call to report in user-facing errors.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
@@ -12,9 +13,15 @@ struc_parser_wrapper <- function(
   x,
   parser,
   on_failure = "error",
+  progress = FALSE,
   call = rlang::caller_env()
 ) {
-  on_failure <- validate_struc_parser_wrapper_args(x, on_failure, call = call)
+  on_failure <- validate_struc_parser_wrapper_args(
+    x,
+    on_failure,
+    progress,
+    call = call
+  )
   wrapper_input <- prepare_struc_parser_input(x)
 
   if (wrapper_input$all_na) {
@@ -24,7 +31,11 @@ struc_parser_wrapper <- function(
     ))
   }
 
-  parsed_unique <- parse_unique_structures(wrapper_input$unique_x, parser)
+  parsed_unique <- parse_unique_structures(
+    wrapper_input$unique_x,
+    parser,
+    progress = progress
+  )
   abort_on_invalid_parse(
     parsed_unique$invalid_unique_x,
     on_failure,
@@ -49,12 +60,14 @@ struc_parser_wrapper <- function(
 #'
 #' @param x A character vector of structure strings.
 #' @param on_failure How to handle parsing failures.
+#' @param progress Whether to show a progress bar while parsing.
 #' @param call The call to report in user-facing errors.
 #'
 #' @return The validated `on_failure` value.
 #' @noRd
-validate_struc_parser_wrapper_args <- function(x, on_failure, call) {
+validate_struc_parser_wrapper_args <- function(x, on_failure, progress, call) {
   checkmate::assert_character(x)
+  checkmate::assert_flag(progress)
   rlang::arg_match(
     on_failure,
     values = c("error", "na"),
@@ -87,10 +100,11 @@ prepare_struc_parser_input <- function(x) {
 #'
 #' @param unique_x A character vector of unique, non-`NA` structure strings.
 #' @param parser A parser function that returns one glycan graph per string.
+#' @param progress Whether to show a progress bar while parsing.
 #'
 #' @return A list containing valid and invalid unique parse results.
 #' @noRd
-parse_unique_structures <- function(unique_x, parser) {
+parse_unique_structures <- function(unique_x, parser, progress = FALSE) {
   safe_parse_one_structure <- purrr::possibly(
     parse_one_structure,
     otherwise = NA
@@ -98,7 +112,8 @@ parse_unique_structures <- function(unique_x, parser) {
   parsed_unique_structures <- purrr::map(
     unique_x,
     safe_parse_one_structure,
-    parser = parser
+    parser = parser,
+    .progress = progress
   )
   invalid_mask <- purrr::map_lgl(parsed_unique_structures, ~ identical(.x, NA))
   list(

--- a/man/auto_parse.Rd
+++ b/man/auto_parse.Rd
@@ -4,13 +4,15 @@
 \alias{auto_parse}
 \title{Automatic Structure Parsing}
 \usage{
-auto_parse(x, on_failure = "error")
+auto_parse(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of structure strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_glycam_iupac.Rd
+++ b/man/parse_glycam_iupac.Rd
@@ -4,7 +4,7 @@
 \alias{parse_glycam_iupac}
 \title{Parse GlyCAM IUPAC Structures}
 \usage{
-parse_glycam_iupac(x, on_failure = "error")
+parse_glycam_iupac(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of GlyCAM IUPAC strings. NA values are allowed
@@ -12,6 +12,8 @@ and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -4,13 +4,15 @@
 \alias{parse_glycoct}
 \title{Parse GlycoCT Structures}
 \usage{
-parse_glycoct(x, on_failure = "error")
+parse_glycoct(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_compact.Rd
+++ b/man/parse_iupac_compact.Rd
@@ -4,7 +4,7 @@
 \alias{parse_iupac_compact}
 \title{Parse IUPAC-compact Structures}
 \usage{
-parse_iupac_compact(x, on_failure = "error")
+parse_iupac_compact(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-compact strings. NA values are allowed
@@ -12,6 +12,8 @@ and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_condensed.Rd
+++ b/man/parse_iupac_condensed.Rd
@@ -4,13 +4,15 @@
 \alias{parse_iupac_condensed}
 \title{Parse IUPAC-condensed Structures}
 \usage{
-parse_iupac_condensed(x, on_failure = "error")
+parse_iupac_condensed(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-condensed strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_extended.Rd
+++ b/man/parse_iupac_extended.Rd
@@ -4,13 +4,15 @@
 \alias{parse_iupac_extended}
 \title{Parse IUPAC-extended Structures}
 \usage{
-parse_iupac_extended(x, on_failure = "error")
+parse_iupac_extended(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-extended strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_short.Rd
+++ b/man/parse_iupac_short.Rd
@@ -4,13 +4,15 @@
 \alias{parse_iupac_short}
 \title{Parse IUPAC-short Structures}
 \usage{
-parse_iupac_short(x, on_failure = "error")
+parse_iupac_short(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-short strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_linear_code.Rd
+++ b/man/parse_linear_code.Rd
@@ -4,13 +4,15 @@
 \alias{parse_linear_code}
 \title{Parse Linear Code Structures}
 \usage{
-parse_linear_code(x, on_failure = "error")
+parse_linear_code(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of Linear Code strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_pglyco_struc.Rd
+++ b/man/parse_pglyco_struc.Rd
@@ -4,13 +4,15 @@
 \alias{parse_pglyco_struc}
 \title{Parse pGlyco Structures}
 \usage{
-parse_pglyco_struc(x, on_failure = "error")
+parse_pglyco_struc(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_strucgp_struc.Rd
+++ b/man/parse_strucgp_struc.Rd
@@ -4,13 +4,15 @@
 \alias{parse_strucgp_struc}
 \title{Parse StrucGP Structures}
 \usage{
-parse_strucgp_struc(x, on_failure = "error")
+parse_strucgp_struc(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -4,13 +4,15 @@
 \alias{parse_wurcs}
 \title{Parse WURCS Structures}
 \usage{
-parse_wurcs(x, on_failure = "error")
+parse_wurcs(x, on_failure = "error", progress = FALSE)
 }
 \arguments{
 \item{x}{A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.}
 
 \item{on_failure}{How to handle parsing failures. \code{"error"} aborts when a
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
+
+\item{progress}{Whether to show a progress bar while parsing.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,0 +1,22 @@
+parser_progress_examples <- list(
+  auto_parse = "Gal(b1-3)GlcNAc(b1-4)Glc(a1-",
+  parse_glycam_iupac = "DGlcpNAcb1-OH",
+  parse_glycoct = "RES\n1b:x-HEX-x:x",
+  parse_iupac_compact = "Galb1-3GlcNAc",
+  parse_iupac_condensed = "Gal(b1-3)GlcNAc(b1-4)Glc(a1-",
+  parse_iupac_extended = "beta-D-Galp-(1->3)-alpha-D-GalpNAc-(1->",
+  parse_iupac_short = "Neu5Aca3Gala3(Fuca6)GlcNAcb-",
+  parse_linear_code = "Ma3(Ma6)Mb4GNb4GNb",
+  parse_pglyco_struc = "(N)",
+  parse_strucgp_struc = "A2B2C1D1E1F1fedD1E1F1feE1F1fedcba",
+  parse_wurcs = "WURCS=2.0/1,0,0/[a2122h-1x_1-5]/1/"
+)
+
+purrr::iwalk(parser_progress_examples, function(input, parser_name) {
+  test_that(paste(parser_name, "accepts progress"), {
+    parser <- get(parser_name, envir = asNamespace("glyparse"))
+
+    expect_true("progress" %in% names(formals(parser)))
+    expect_no_error(suppressMessages(parser(input, progress = TRUE)))
+  })
+})


### PR DESCRIPTION
## Summary

Add an opt-in `progress` argument to parser APIs so large parsing jobs can show purrr's native progress bar.

## Details

- Add `progress = FALSE` to `auto_parse()` and all exported `parse_*()` functions.
- Thread `progress` through the shared parser wrapper to `purrr::map(.progress = progress)` when parsing unique non-`NA` inputs.
- Document the new argument in parser Rd files.
- Add parser-wide regression coverage that each parser accepts `progress = TRUE`.
- Add a NEWS entry for the new parser progress argument.

## Verification

- `Rscript -e 'devtools::document()'`
- `Rscript -e 'devtools::test(filter = "progress")'` — 22 passed
- `Rscript -e 'devtools::test()'` — 991 passed
- `git diff --check`

Closes #20 