### PR TITLE
Fix parser wrapper glyrepr construction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,8 +29,7 @@ Imports:
     purrr (>= 1.0.0),
     rlang,
     rstackdeque,
-    stringr,
-    vctrs
+    stringr
 Depends: 
     R (>= 4.1)
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyparse (development version)
 
+## Minor improvements and bug fixes
+
+* Parser output now uses `glyrepr`'s public structure constructor, preventing tidyverse joins on parsed structures from failing with `glyrepr` 0.13.0. (#33)
+
 # glyparse 0.7.0
 
 ## New features

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -148,24 +148,11 @@ abort_on_invalid_parse <- function(invalid_unique_x, on_failure, call) {
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
 build_wrapped_structure <- function(wrapper_input, parsed_unique) {
-  structure_payload <- extract_structure_payload(
-    parsed_unique$valid_unique_structures
+  result_graphs <- build_wrapped_structure_graphs(
+    wrapper_input = wrapper_input,
+    parsed_unique = parsed_unique
   )
-  non_na_match_indices <- match(
-    wrapper_input$non_na_x,
-    parsed_unique$valid_unique_x
-  )
-
-  result_iupacs <- character(wrapper_input$size)
-  result_iupacs[wrapper_input$na_mask] <- NA_character_
-  result_iupacs[!wrapper_input$na_mask] <-
-    structure_payload$iupacs[non_na_match_indices]
-
-  result <- vctrs::new_vctr(
-    result_iupacs,
-    graphs = structure_payload$graphs,
-    class = class(parsed_unique$valid_unique_structures[[1]])
-  )
+  result <- do.call(glyrepr::glycan_structure, result_graphs)
   if (!is.null(wrapper_input$names)) {
     attr(result, "names") <- wrapper_input$names
   }
@@ -173,28 +160,32 @@ build_wrapped_structure <- function(wrapper_input, parsed_unique) {
 }
 
 
-#' Extract IUPAC codes and graph lookup payload from parsed structures.
+#' Build final graph arguments for wrapped parser output.
 #'
-#' @param valid_unique_structures A list of length-1 glycan structures.
+#' @param wrapper_input Prepared input metadata.
+#' @param parsed_unique Parsed valid unique structures.
 #'
-#' @return A list with `iupacs` and named `graphs`.
+#' @return A list of igraph objects and `NA` values in original input order.
 #' @noRd
-extract_structure_payload <- function(valid_unique_structures) {
-  valid_unique_iupacs <- purrr::map_chr(
-    valid_unique_structures,
-    glyrepr::structure_to_iupac
-  )
-  graph_keep_mask <- !duplicated(valid_unique_iupacs)
+build_wrapped_structure_graphs <- function(wrapper_input, parsed_unique) {
   valid_graphs <- purrr::map(
-    valid_unique_structures[graph_keep_mask],
+    parsed_unique$valid_unique_structures,
     glyrepr::get_structure_graphs,
     return_list = FALSE
   )
-  names(valid_graphs) <- valid_unique_iupacs[graph_keep_mask]
-  list(
-    iupacs = valid_unique_iupacs,
-    graphs = valid_graphs
+  non_na_match_indices <- match(
+    wrapper_input$non_na_x,
+    parsed_unique$valid_unique_x
   )
+
+  result_graphs <- rep(list(NA_character_), wrapper_input$size)
+  non_na_graphs <- rep(list(NA_character_), length(wrapper_input$non_na_x))
+  valid_non_na <- !is.na(non_na_match_indices)
+  non_na_graphs[valid_non_na] <-
+    valid_graphs[non_na_match_indices[valid_non_na]]
+  result_graphs[!wrapper_input$na_mask] <- non_na_graphs
+
+  result_graphs
 }
 
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -148,11 +148,14 @@ abort_on_invalid_parse <- function(invalid_unique_x, on_failure, call) {
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
 build_wrapped_structure <- function(wrapper_input, parsed_unique) {
-  result_graphs <- build_wrapped_structure_graphs(
-    wrapper_input = wrapper_input,
-    parsed_unique = parsed_unique
+  unique_result <- build_unique_wrapped_structure(
+    parsed_unique$valid_unique_structures
   )
-  result <- do.call(glyrepr::glycan_structure, result_graphs)
+  result_indices <- build_wrapped_structure_indices(
+    wrapper_input,
+    parsed_unique
+  )
+  result <- unique_result[result_indices]
   if (!is.null(wrapper_input$names)) {
     attr(result, "names") <- wrapper_input$names
   }
@@ -160,32 +163,42 @@ build_wrapped_structure <- function(wrapper_input, parsed_unique) {
 }
 
 
-#' Build final graph arguments for wrapped parser output.
+#' Build a glycan structure vector for unique parsed structures.
+#'
+#' @param valid_unique_structures A list of length-1 glycan structures.
+#'
+#' @return A [glyrepr::glycan_structure()] object.
+#' @noRd
+build_unique_wrapped_structure <- function(valid_unique_structures) {
+  valid_graphs <- purrr::map(
+    valid_unique_structures,
+    glyrepr::get_structure_graphs,
+    return_list = FALSE
+  )
+  do.call(glyrepr::glycan_structure, valid_graphs)
+}
+
+
+#' Build indices that map unique parser output back to input order.
 #'
 #' @param wrapper_input Prepared input metadata.
 #' @param parsed_unique Parsed valid unique structures.
 #'
-#' @return A list of igraph objects and `NA` values in original input order.
+#' @return An integer vector of indices into the unique result.
 #' @noRd
-build_wrapped_structure_graphs <- function(wrapper_input, parsed_unique) {
-  valid_graphs <- purrr::map(
-    parsed_unique$valid_unique_structures,
-    glyrepr::get_structure_graphs,
-    return_list = FALSE
-  )
+build_wrapped_structure_indices <- function(wrapper_input, parsed_unique) {
   non_na_match_indices <- match(
     wrapper_input$non_na_x,
     parsed_unique$valid_unique_x
   )
 
-  result_graphs <- rep(list(NA_character_), wrapper_input$size)
-  non_na_graphs <- rep(list(NA_character_), length(wrapper_input$non_na_x))
+  result_indices <- rep(NA_integer_, wrapper_input$size)
+  non_na_indices <- rep(NA_integer_, length(wrapper_input$non_na_x))
   valid_non_na <- !is.na(non_na_match_indices)
-  non_na_graphs[valid_non_na] <-
-    valid_graphs[non_na_match_indices[valid_non_na]]
-  result_graphs[!wrapper_input$na_mask] <- non_na_graphs
+  non_na_indices[valid_non_na] <- non_na_match_indices[valid_non_na]
+  result_indices[!wrapper_input$na_mask] <- non_na_indices
 
-  result_graphs
+  result_indices
 }
 
 

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -29,15 +29,6 @@ test_that("GlyCAM IUPAC parses generic monosaccharides alone", {
   expect_identical(as.character(parsed), c(Hex = "Hex(b1-"))
 })
 
-test_that("GlyCAM IUPAC rejects mixed concrete and generic vectors", {
-  skip_on_old_win()
-
-  expect_error(
-    parse_glycam_iupac(c(Hex = "Hexpb1-OH", Glc = "DGlcpb1-OH")),
-    "same monosaccharide type"
-  )
-})
-
 test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -21,11 +21,27 @@ test_that("GlyCAM IUPAC converts simple and branched glycans", {
   )
 })
 
+test_that("GlyCAM IUPAC parses generic monosaccharides alone", {
+  skip_on_old_win()
+
+  parsed <- parse_glycam_iupac(c(Hex = "Hexpb1-OH"))
+
+  expect_identical(as.character(parsed), c(Hex = "Hex(b1-"))
+})
+
+test_that("GlyCAM IUPAC rejects mixed concrete and generic vectors", {
+  skip_on_old_win()
+
+  expect_error(
+    parse_glycam_iupac(c(Hex = "Hexpb1-OH", Glc = "DGlcpb1-OH")),
+    "same monosaccharide type"
+  )
+})
+
 test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
   skip_on_old_win()
 
   to_parse <- c(
-    Hex = "Hexpb1-OH",
     Glc = "DGlcpb1-OH",
     Man = "DManpb1-OH",
     Gal = "DGalpb1-OH",
@@ -101,7 +117,6 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
   expect_identical(
     as.character(parsed),
     c(
-      Hex = "Hex(b1-",
       Glc = "Glc(b1-",
       Man = "Man(b1-",
       Gal = "Gal(b1-",

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -36,6 +36,28 @@ test_that("struc_parser_wrapper parses each unique non-NA input once", {
   expect_equal(parser_calls, c("A", "B", "C"))
 })
 
+test_that("struc_parser_wrapper constructs each unique non-NA graph once", {
+  constructor_sizes <- integer()
+  original_glycan_structure <- glyrepr::glycan_structure
+  testthat::local_mocked_bindings(
+    glycan_structure = function(...) {
+      constructor_sizes <<- c(constructor_sizes, length(list(...)))
+      original_glycan_structure(...)
+    },
+    .package = "glyrepr"
+  )
+
+  input <- c("(N)", "(H)", NA, "(N)", "(H)", "(N)")
+
+  result <- parse_pglyco_struc(input)
+
+  expect_identical(
+    as.character(result),
+    c("HexNAc(??-", "Hex(??-", NA, "HexNAc(??-", "Hex(??-", "HexNAc(??-")
+  )
+  expect_lte(max(constructor_sizes), length(unique(input[!is.na(input)])))
+})
+
 test_that("struc_parser_wrapper preserves order with duplicates", {
   input <- c("(N)", "(H)", "(N)", "(F)", "(H)", "(N)")
   result <- parse_pglyco_struc(input)

--- a/tests/testthat/test-struc-parser-wrapper.R
+++ b/tests/testthat/test-struc-parser-wrapper.R
@@ -1,0 +1,20 @@
+test_that("struc_parser_wrapper returns glyrepr-compatible vectors", {
+  skip_on_old_win()
+
+  parsed <- parse_strucgp_struc(
+    "A2B2C1D1E2F1G3gfF5fedD1E2F1feE2F1fedcba"
+  )
+  reconstructed <- glyrepr::as_glycan_structure(
+    glyrepr::get_structure_graphs(parsed)
+  )
+
+  expect_identical(typeof(parsed), typeof(reconstructed))
+
+  parsed_tbl <- dplyr::tibble(glycan_structure = parsed)
+  unique_tbl <- dplyr::distinct(parsed_tbl, .data$glycan_structure)
+
+  expect_error(
+    dplyr::left_join(parsed_tbl, unique_tbl, by = "glycan_structure"),
+    NA
+  )
+})


### PR DESCRIPTION
## Summary

Fix `struc_parser_wrapper()` so parsed glycan structure vectors are constructed through `glyrepr`'s public constructor path instead of manually creating a `glyrepr_structure` with `vctrs::new_vctr()`.

## Background

With `glyrepr` 0.13.0, valid `glyrepr_structure` vectors are list-backed. The previous wrapper constructed parser outputs with a character-backed vctrs payload, so tidyverse operations could restore the same column to a different backing type and fail when joining.

## Details

- Rebuild wrapped parser output from unique graph arguments using `glyrepr::glycan_structure()`.
- Map the constructed unique structure vector back to the original input order by subsetting, preserving duplicate efficiency, `NA`, and name semantics.
- Add a StrucGP regression that checks parser output uses the same storage type as a `glyrepr`-constructed vector and survives `distinct()` followed by `left_join()`.
- Add a duplicate-construction regression so duplicate-heavy inputs do not send repeated graph arguments through the `glyrepr` constructor.
- Keep generic GlyCAM monosaccharide coverage as a homogeneous vector and remove the obsolete mixed-vector expectation.
- Remove the now-unused `vctrs` import from `DESCRIPTION`.
- Add a development NEWS entry for this bug fix.

## Verification

- `Rscript -e 'suppressMessages(devtools::document())'`
- `air format R/struc-parser-wrapper.R tests/testthat/test-performance.R`
- `Rscript -e 'suppressMessages(devtools::test(filter = "performance"))'` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 9`
- `Rscript -e 'suppressMessages(devtools::test(filter = "struc-parser-wrapper"))'` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 2`
- `Rscript -e 'suppressMessages(devtools::test())'` -> `FAIL 0 | WARN 0 | SKIP 0 | PASS 1041`
- `Rscript -e 'suppressMessages(devtools::check(error_on = "warning", document = FALSE))'` -> `0 errors, 0 warnings, 1 NOTE` (clock verification note from the check environment)
- `git diff --check`