### PR TITLE
feat: batch parser structure construction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    glyrepr (>= 0.13.0.9000),
+    glyrepr (>= 0.14.0),
     igraph,
     purrr (>= 1.0.0),
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    glyrepr (>= 0.12.0),
+    glyrepr (>= 0.13.0.9000),
     igraph,
     purrr (>= 1.0.0),
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glyparse (development version)
 
+* Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
+
 # glyparse 0.7.1
 
 ## Minor improvements and bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # glyparse (development version)
 
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
+* Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 
 # glyparse 0.7.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
+* Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).
 
 # glyparse 0.7.1
 

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -39,7 +39,11 @@
 #' auto_parse(x)
 #'
 #' @export
-auto_parse <- function(x, on_failure = "error", progress = FALSE) {
+auto_parse <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   struc_parser_wrapper(
     x,
     do_auto_parse,

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -31,9 +31,9 @@
 #'
 #' @export
 parse_glycam_iupac <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_glycam_iupac,
+    convert_glycam_iupac_to_condensed,
     on_failure = on_failure,
     progress = progress
   )
@@ -53,9 +53,9 @@ do_parse_glycam_iupac <- function(x) {
 
 #' Convert GlyCAM IUPAC to IUPAC-condensed notation
 #'
-#' @param x A single GlyCAM IUPAC string.
+#' @param x A character vector of GlyCAM IUPAC strings.
 #'
-#' @return A character scalar containing IUPAC-condensed notation.
+#' @return A character vector containing IUPAC-condensed notation.
 #' @noRd
 convert_glycam_iupac_to_condensed <- function(x) {
   token_pattern <- paste(
@@ -64,13 +64,16 @@ convert_glycam_iupac_to_condensed <- function(x) {
     "\\]",
     sep = "|"
   )
-  tokens <- stringr::str_extract_all(x, token_pattern)[[1]]
+  tokens <- stringr::str_extract_all(x, token_pattern)
 
-  if (length(tokens) == 0 || paste0(tokens, collapse = "") != x) {
+  reconstructed <- purrr::map_chr(tokens, ~ paste0(.x, collapse = ""))
+  if (any(lengths(tokens) == 0 | reconstructed != x)) {
     cli::cli_abort("Failed to parse the GlyCAM IUPAC string.")
   }
 
-  paste0(purrr::map_chr(tokens, convert_glycam_iupac_token), collapse = "")
+  purrr::map_chr(tokens, function(tokens) {
+    paste0(purrr::map_chr(tokens, convert_glycam_iupac_token), collapse = "")
+  })
 }
 
 

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -30,7 +30,11 @@
 #' @seealso [parse_iupac_condensed()]
 #'
 #' @export
-parse_glycam_iupac <- function(x, on_failure = "error", progress = FALSE) {
+parse_glycam_iupac <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     convert_glycam_iupac_to_condensed,

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -17,6 +17,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -33,12 +35,18 @@
 #' parse_glycoct(glycoct)
 #'
 #' @export
-parse_glycoct <- function(x, on_failure = "error", progress = FALSE) {
+parse_glycoct <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_glycoct,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -27,7 +27,11 @@
 #' @seealso [parse_iupac_condensed()]
 #'
 #' @export
-parse_iupac_compact <- function(x, on_failure = "error", progress = FALSE) {
+parse_iupac_compact <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     convert_iupac_compact_to_condensed,

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -376,18 +376,18 @@ iupac_compact_monosaccharide_pattern <- local({
 
 #' Get the default reducing-end anomer position for a monosaccharide
 #'
-#' @param mono A monosaccharide name.
+#' @param mono A character vector of monosaccharide names.
 #'
-#' @return A character scalar.
+#' @return A character vector of default anomer positions.
 #' @noRd
 iupac_compact_default_anomer_pos <- function(mono) {
-  if (glyrepr::get_mono_type(mono) != "concrete") {
-    # TODO: Remove this fallback when glyrepr::get_mono_type() and
-    # glyrepr::get_anomer_pos() support generic glycans.
-    return("1")
+  anomer_pos <- rep("1", length(mono))
+  concrete <- glyrepr::get_mono_type(mono) == "concrete"
+  if (any(concrete)) {
+    anomer_pos[concrete] <- glyrepr::get_anomer_pos(mono[concrete])
   }
 
-  glyrepr::get_anomer_pos(mono)
+  anomer_pos
 }
 
 

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -28,9 +28,9 @@
 #'
 #' @export
 parse_iupac_compact <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_iupac_compact,
+    convert_iupac_compact_to_condensed,
     on_failure = on_failure,
     progress = progress
   )
@@ -44,21 +44,21 @@ parse_iupac_compact <- function(x, on_failure = "error", progress = FALSE) {
 #' @return A glycan graph.
 #' @noRd
 do_parse_iupac_compact <- function(x) {
-  if (is_iupac_compact_alditol(x)) {
-    warn_iupac_compact_alditol()
-  }
-
   do_parse_iupac_condensed(convert_iupac_compact_to_condensed(x))
 }
 
 
 #' Convert IUPAC-compact to IUPAC-condensed notation
 #'
-#' @param x A single IUPAC-compact string.
+#' @param x A character vector of IUPAC-compact strings.
 #'
-#' @return A character scalar containing IUPAC-condensed notation.
+#' @return A character vector containing IUPAC-condensed notation.
 #' @noRd
 convert_iupac_compact_to_condensed <- function(x) {
+  if (any(is_iupac_compact_alditol(x))) {
+    warn_iupac_compact_alditol()
+  }
+
   x |>
     normalize_iupac_compact_aliases() |>
     normalize_iupac_compact_modifiers() |>
@@ -71,9 +71,9 @@ convert_iupac_compact_to_condensed <- function(x) {
 
 #' Normalize IUPAC-compact monosaccharide aliases
 #'
-#' @param x A single IUPAC-compact string.
+#' @param x A character vector of IUPAC-compact strings.
 #'
-#' @return A character scalar with aliases normalized.
+#' @return A character vector with aliases normalized.
 #' @noRd
 normalize_iupac_compact_aliases <- function(x) {
   x |>
@@ -85,9 +85,9 @@ normalize_iupac_compact_aliases <- function(x) {
 
 #' Normalize IUPAC-compact parenthesized residue modifiers
 #'
-#' @param x A single IUPAC-compact string.
+#' @param x A character vector of IUPAC-compact strings.
 #'
-#' @return A character scalar with modifiers moved after monosaccharide names.
+#' @return A character vector with modifiers moved after monosaccharide names.
 #' @noRd
 normalize_iupac_compact_modifiers <- function(x) {
   modifier_pattern <- iupac_compact_modifier_before_mono_pattern()
@@ -108,9 +108,9 @@ normalize_iupac_compact_modifiers <- function(x) {
 
 #' Normalize IUPAC-compact branch delimiters
 #'
-#' @param x A single IUPAC-compact string.
+#' @param x A character vector of IUPAC-compact strings.
 #'
-#' @return A character scalar with IUPAC-condensed branch delimiters.
+#' @return A character vector with IUPAC-condensed branch delimiters.
 #' @noRd
 normalize_iupac_compact_branches <- function(x) {
   x |>
@@ -121,9 +121,9 @@ normalize_iupac_compact_branches <- function(x) {
 
 #' Normalize IUPAC-compact linkage notation
 #'
-#' @param x A single IUPAC-compact string.
+#' @param x A character vector of IUPAC-compact strings.
 #'
-#' @return A character scalar with IUPAC-condensed linkage notation.
+#' @return A character vector with IUPAC-condensed linkage notation.
 #' @noRd
 normalize_iupac_compact_linkages <- function(x) {
   x |>
@@ -137,49 +137,56 @@ normalize_iupac_compact_linkages <- function(x) {
 
 #' Normalize IUPAC-compact alditol suffixes
 #'
-#' @param x A single partially normalized IUPAC-compact string.
+#' @param x A character vector of partially normalized IUPAC-compact strings.
 #'
-#' @return A character scalar with alditol suffix removed and reducing-end
+#' @return A character vector with alditol suffixes removed and reducing-end
 #'   anomer set to unknown.
 #' @noRd
 normalize_iupac_compact_alditol <- function(x) {
-  if (!is_iupac_compact_alditol(x)) {
+  alditol <- is_iupac_compact_alditol(x)
+  if (!any(alditol)) {
     return(x)
   }
 
-  x <- stringr::str_remove(x, "\\+aldi$")
-  terminal <- iupac_compact_terminal_match(x)
-  if (is.null(terminal)) {
-    return(x)
-  }
-
-  replacement <- paste0(terminal$mono, terminal$modifiers)
-  stringr::str_replace(x, iupac_compact_terminal_pattern(), replacement)
+  x[alditol] <- purrr::map_chr(x[alditol], function(value) {
+    value <- stringr::str_remove(value, "\\+aldi$")
+    terminal <- iupac_compact_terminal_match(value)
+    if (is.null(terminal)) {
+      return(value)
+    }
+    replacement <- paste0(terminal$mono, terminal$modifiers)
+    stringr::str_replace(value, iupac_compact_terminal_pattern(), replacement)
+  })
+  x
 }
 
 
 #' Normalize the reducing-end terminal of an IUPAC-compact string
 #'
-#' @param x A single partially normalized IUPAC-compact string.
+#' @param x A character vector of partially normalized IUPAC-compact strings.
 #'
-#' @return A character scalar with a reducing-end IUPAC-condensed linkage.
+#' @return A character vector with reducing-end IUPAC-condensed linkages.
 #' @noRd
 normalize_iupac_compact_terminal <- function(x) {
-  terminal_match <- iupac_compact_terminal_match(x)
-  if (is.null(terminal_match)) {
+  terminal_match <- stringr::str_match(x, iupac_compact_terminal_pattern())
+  matched <- !is.na(terminal_match[, "mono"])
+  if (!any(matched)) {
     return(x)
   }
 
-  mono <- terminal_match$mono
-  modifiers <- terminal_match$modifiers
-  anomer <- terminal_match$anomer
-  if (is.na(anomer)) {
-    anomer <- "?"
-  }
+  mono <- terminal_match[matched, "mono"]
+  modifiers <- terminal_match[matched, "modifiers"]
+  anomer <- terminal_match[matched, "anomer"]
+  anomer[is.na(anomer)] <- "?"
 
   anomer_pos <- iupac_compact_default_anomer_pos(mono)
   terminal <- stringr::str_glue("{mono}{modifiers}({anomer}{anomer_pos}-")
-  stringr::str_replace(x, iupac_compact_terminal_pattern(), terminal)
+  x[matched] <- stringr::str_replace(
+    x[matched],
+    iupac_compact_terminal_pattern(),
+    terminal
+  )
+  x
 }
 
 
@@ -187,10 +194,10 @@ normalize_iupac_compact_terminal <- function(x) {
 #'
 #' @param x A single structure string.
 #'
-#' @return A logical scalar.
+#' @return A logical vector.
 #' @noRd
 is_iupac_compact_alditol <- function(x) {
-  isTRUE(stringr::str_ends(x, stringr::fixed("+aldi")))
+  stringr::str_ends(x, stringr::fixed("+aldi"))
 }
 
 

--- a/R/parse-iupac-condensed.R
+++ b/R/parse-iupac-condensed.R
@@ -35,7 +35,11 @@
 #' @seealso [parse_iupac_short()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_condensed <- function(x, on_failure = "error", progress = FALSE) {
+parse_iupac_condensed <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     on_failure = on_failure,

--- a/R/parse-iupac-condensed.R
+++ b/R/parse-iupac-condensed.R
@@ -36,9 +36,8 @@
 #'
 #' @export
 parse_iupac_condensed <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_iupac_condensed,
     on_failure = on_failure,
     progress = progress
   )

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -26,9 +26,9 @@
 #'
 #' @export
 parse_iupac_extended <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_iupac_extended,
+    function(x) convert_ext_to_con(normalize_iupac_extended(x)),
     on_failure = on_failure,
     progress = progress
   )
@@ -91,9 +91,11 @@ convert_ext_to_con <- function(x) {
     "\\]",
     sep = "|"
   )
-  tokens <- stringr::str_extract_all(x, token_pattern)[[1]]
-  new_tokens <- purrr::map_chr(tokens, convert_token)
-  paste(new_tokens, collapse = "")
+  tokens <- stringr::str_extract_all(x, token_pattern)
+  purrr::map_chr(tokens, function(tokens) {
+    new_tokens <- purrr::map_chr(tokens, convert_token)
+    paste0(new_tokens, collapse = "")
+  })
 }
 
 

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -25,7 +25,11 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_short()]
 #'
 #' @export
-parse_iupac_extended <- function(x, on_failure = "error", progress = FALSE) {
+parse_iupac_extended <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     function(x) convert_ext_to_con(normalize_iupac_extended(x)),

--- a/R/parse-iupac-short.R
+++ b/R/parse-iupac-short.R
@@ -28,7 +28,11 @@
 #' @seealso [parse_iupac_condensed()], [parse_iupac_extended()]
 #'
 #' @export
-parse_iupac_short <- function(x, on_failure = "error", progress = FALSE) {
+parse_iupac_short <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     convert_short_to_condensed,

--- a/R/parse-iupac-short.R
+++ b/R/parse-iupac-short.R
@@ -29,9 +29,9 @@
 #'
 #' @export
 parse_iupac_short <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_iupac_short,
+    convert_short_to_condensed,
     on_failure = on_failure,
     progress = progress
   )
@@ -63,14 +63,17 @@ convert_short_to_condensed <- function(x) {
     "({full_mono_pattern})([ab\\?])-?(\\d+(?:/\\d+)*|\\?)"
   )
   token_pattern <- paste(residue_pattern, "\\(", "\\)", sep = "|")
-  tokens <- stringr::str_extract_all(x, token_pattern)[[1]]
+  tokens <- stringr::str_extract_all(x, token_pattern)
 
   # The last residue is special because it doesn't have pos 2, e.g. "Mana-"
   last_residue_pattern <- stringr::str_glue("({full_mono_pattern})([ab\\?])-$")
-  last_token <- stringr::str_extract(x, last_residue_pattern)
+  last_tokens <- stringr::str_extract(x, last_residue_pattern)
 
   # Validate if x has been thoroughly parsed into tokens.
-  if (paste0(c(tokens, last_token), collapse = "") != x) {
+  reconstructed <- purrr::map2_chr(tokens, last_tokens, function(tokens, last) {
+    paste0(c(tokens, last), collapse = "")
+  })
+  if (any(reconstructed != x)) {
     rlang::abort("Failed to parse the IUPAC-short string.")
   }
 
@@ -96,16 +99,20 @@ convert_short_to_condensed <- function(x) {
       })
     )
   }
-  processed_tokens <- purrr::map_chr(tokens, process_token)
+  processed_tokens <- purrr::map(tokens, ~ purrr::map_chr(.x, process_token))
 
   # Now handle the last residue.
-  last_processed_token <- local({
-    match <- stringr::str_match(last_token, last_residue_pattern)
+  last_processed_tokens <- local({
+    match <- stringr::str_match(last_tokens, last_residue_pattern)
     mono <- match[, 2]
     anomer <- match[, 3]
     pos1 <- decide_anomer_pos(mono)
     paste0(mono, "(", anomer, pos1, "-")
   })
 
-  paste0(c(processed_tokens, last_processed_token), collapse = "")
+  purrr::map2_chr(
+    processed_tokens,
+    last_processed_tokens,
+    ~ paste0(c(.x, .y), collapse = "")
+  )
 }

--- a/R/parse-kcf.R
+++ b/R/parse-kcf.R
@@ -7,6 +7,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -31,12 +33,18 @@
 #' parse_kcf(kcf)
 #'
 #' @export
-parse_kcf <- function(x, on_failure = "error", progress = FALSE) {
+parse_kcf <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_kcf,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -15,7 +15,11 @@
 #' parse_linear_code(linear_code)
 #'
 #' @export
-parse_linear_code <- function(x, on_failure = "error", progress = FALSE) {
+parse_linear_code <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE
+) {
   normalized_struc_parser_wrapper(
     x,
     convert_linear_to_iupac,

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -16,9 +16,9 @@
 #'
 #' @export
 parse_linear_code <- function(x, on_failure = "error", progress = FALSE) {
-  struc_parser_wrapper(
+  normalized_struc_parser_wrapper(
     x,
-    do_parse_linear_code,
+    convert_linear_to_iupac,
     on_failure = on_failure,
     progress = progress
   )

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -16,6 +16,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -24,12 +26,18 @@
 #' parse_linucs(linucs)
 #'
 #' @export
-parse_linucs <- function(x, on_failure = "error", progress = FALSE) {
+parse_linucs <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_linucs,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/parse-pglyco.R
+++ b/R/parse-pglyco.R
@@ -38,21 +38,26 @@ do_parse_pglyco_struc <- function(x) {
     stringr::str_replace_all(x, "[^()]", ""),
     ""
   )
-  current_node <- 1
+  edge_count <- sum(parentheses == "(") - 1L
+  edges <- integer(edge_count * 2L)
+  edge_index <- 0L
+  current_node <- 1L
   node_stack <- rstackdeque::rstack()
-  node_stack <- rstackdeque::insert_top(node_stack, 1)
+  node_stack <- rstackdeque::insert_top(node_stack, 1L)
   for (i in 2:length(parentheses)) {
     if (parentheses[[i]] == "(") {
-      current_node <- current_node + 1
-      g <- igraph::add_edges(
-        g,
-        c(rstackdeque::peek_top(node_stack), current_node)
-      )
+      current_node <- current_node + 1L
+      edge_index <- edge_index + 1L
+      edges[[2L * edge_index - 1L]] <- rstackdeque::peek_top(node_stack)
+      edges[[2L * edge_index]] <- current_node
       node_stack <- rstackdeque::insert_top(node_stack, current_node)
     } else {
       # must be ")"
       node_stack <- rstackdeque::without_top(node_stack)
     }
+  }
+  if (length(edges) > 0L) {
+    g <- igraph::add_edges(g, edges)
   }
 
   # Map pGlyco monosaccharide codes to standard names

--- a/R/parse-pglyco.R
+++ b/R/parse-pglyco.R
@@ -7,6 +7,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -15,12 +17,18 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_pglyco_struc <- function(x, on_failure = "error", progress = FALSE) {
+parse_pglyco_struc <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_pglyco_struc,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/parse-strucgp.R
+++ b/R/parse-strucgp.R
@@ -7,6 +7,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -15,12 +17,18 @@
 #' print(glycan, verbose = TRUE)
 #'
 #' @export
-parse_strucgp_struc <- function(x, on_failure = "error", progress = FALSE) {
+parse_strucgp_struc <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_strucgp_struc,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/parse-strucgp.R
+++ b/R/parse-strucgp.R
@@ -27,8 +27,20 @@ parse_strucgp_struc <- function(x, on_failure = "error", progress = FALSE) {
 
 # Parsing logic of `parse_strucgp_struc()`
 do_parse_strucgp_struc <- function(x) {
-  graph_env <- list(graph = igraph::make_empty_graph())
-  graph <- recur_parse_strucgp(x, graph_env, 0)$graph
+  node_capacity <- stringr::str_count(x, "[A-Z]")
+  state <- new.env(parent = emptyenv())
+  state$count <- 0L
+  state$monos <- character(node_capacity)
+  state$parents <- integer(node_capacity)
+  recur_parse_strucgp(x, state, 0L)
+
+  graph <- igraph::make_empty_graph(n = state$count, directed = TRUE)
+  if (state$count > 1L) {
+    child <- seq.int(2L, state$count)
+    edges <- as.vector(rbind(state$parents[child], child))
+    graph <- igraph::add_edges(graph, edges)
+  }
+
   mono_map <- c(
     "1" = "Hex",
     "2" = "HexNAc",
@@ -36,7 +48,8 @@ do_parse_strucgp_struc <- function(x) {
     "4" = "NeuGc",
     "5" = "dHex"
   )
-  igraph::V(graph)$mono <- mono_map[igraph::V(graph)$mono]
+  igraph::V(graph)$name <- as.character(seq_len(state$count))
+  igraph::V(graph)$mono <- mono_map[state$monos[seq_len(state$count)]]
   igraph::V(graph)$sub <- ""
   igraph::E(graph)$linkage <- "??-?"
   graph$anomer <- "??"
@@ -45,20 +58,20 @@ do_parse_strucgp_struc <- function(x) {
 }
 
 
-recur_parse_strucgp <- function(x, graph_env, last_node) {
+recur_parse_strucgp <- function(x, state, last_node) {
   # Base condition: `x` is "".
   if (x == "") {
-    return(graph_env)
+    return(invisible(NULL))
   }
 
   start <- stringr::str_sub(x, 1, 1)
 
   # If last_node is 0, this is the first layer.
   if (last_node == 0) {
-    mono <- stringr::str_sub(x, 2, 2)
-    graph <- igraph::add_vertices(graph_env$graph, 1, mono = mono, name = "1")
-    graph_env$graph <- graph
-    return(recur_parse_strucgp(stringr::str_sub(x, 3, -2), graph_env, "1"))
+    state$count <- 1L
+    state$monos[[1L]] <- stringr::str_sub(x, 2, 2)
+    recur_parse_strucgp(stringr::str_sub(x, 3, -2), state, 1L)
+    return(invisible(NULL))
   }
 
   # If a branch appears, split `x` and dispatch to the next level.
@@ -66,18 +79,15 @@ recur_parse_strucgp <- function(x, graph_env, last_node) {
     end <- stringr::str_to_lower(start)
     pattern <- stringr::str_glue("{start}.*?{end}")
     for (sub_x in stringr::str_extract_all(x, pattern)[[1]]) {
-      graph_env <- recur_parse_strucgp(sub_x, graph_env, last_node)
+      recur_parse_strucgp(sub_x, state, last_node)
     }
-    return(graph_env)
+    return(invisible(NULL))
   } else {
-    # For layer with no branch, add a node.
-    # Build new graph
-    mono <- stringr::str_sub(x, 2, 2)
-    name = as.character(igraph::vcount(graph_env$graph) + 1)
-    graph <- igraph::add_vertices(graph_env$graph, 1, mono = mono, name = name)
-    graph <- igraph::add_edges(graph, c(last_node, name))
-    graph_env$graph <- graph
-    # Dispatch to the next level
-    return(recur_parse_strucgp(stringr::str_sub(x, 3, -2), graph_env, name))
+    node <- state$count + 1L
+    state$count <- node
+    state$monos[[node]] <- stringr::str_sub(x, 2, 2)
+    state$parents[[node]] <- last_node
+    recur_parse_strucgp(stringr::str_sub(x, 3, -2), state, node)
+    return(invisible(NULL))
   }
 }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -10,6 +10,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -22,12 +24,18 @@
 #' parse_wurcs(wurcs)
 #'
 #' @export
-parse_wurcs <- function(x, on_failure = "error", progress = FALSE) {
+parse_wurcs <- function(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE
+) {
   struc_parser_wrapper(
     x,
     do_parse_wurcs,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
 }
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -56,6 +56,100 @@ struc_parser_wrapper <- function(
 }
 
 
+#' Normalize structure strings and parse their unique IUPAC-condensed forms.
+#'
+#' @param x A character vector of structure strings.
+#' @param normalizer A vectorized function that converts strings to
+#'   IUPAC-condensed notation.
+#' @inheritParams struc_parser_wrapper
+#'
+#' @return A [glyrepr::glycan_structure()] object.
+#' @noRd
+normalized_struc_parser_wrapper <- function(
+  x,
+  normalizer = identity,
+  on_failure = "error",
+  progress = FALSE,
+  call = rlang::caller_env()
+) {
+  on_failure <- validate_struc_parser_wrapper_args(
+    x,
+    on_failure,
+    progress,
+    call = call
+  )
+  wrapper_input <- prepare_struc_parser_input(x)
+
+  if (wrapper_input$all_na) {
+    return(make_na_glycan_structure(
+      wrapper_input$size,
+      names = wrapper_input$names
+    ))
+  }
+
+  normalized_unique <- normalize_unique_structures(
+    wrapper_input$unique_x,
+    normalizer,
+    progress = progress
+  )
+  unique_result <- suppressWarnings(glyrepr::as_glycan_structure(
+    normalized_unique,
+    on_failure = "na"
+  ))
+  invalid_mask <- is.na(unique_result)
+  abort_on_invalid_parse(
+    wrapper_input$unique_x[invalid_mask],
+    on_failure,
+    call = call
+  )
+
+  result <- unique_result[build_normalized_structure_indices(wrapper_input)]
+  if (!is.null(wrapper_input$names)) {
+    attr(result, "names") <- wrapper_input$names
+  }
+  result
+}
+
+
+#' Normalize all unique inputs together, with scalar failure recovery.
+#'
+#' @param unique_x A character vector of unique structure strings.
+#' @param normalizer A vectorized normalization function.
+#' @param progress Whether to show a progress bar during scalar recovery.
+#'
+#' @return A character vector of IUPAC-condensed strings.
+#' @noRd
+normalize_unique_structures <- function(
+  unique_x,
+  normalizer,
+  progress = FALSE
+) {
+  normalized <- tryCatch(normalizer(unique_x), error = identity)
+  if (!inherits(normalized, "error")) {
+    return(normalized)
+  }
+
+  safe_normalize <- purrr::possibly(normalizer, otherwise = NA_character_)
+  purrr::map_chr(unique_x, safe_normalize, .progress = progress)
+}
+
+
+#' Build indices for restoring normalized unique structures to input order.
+#'
+#' @param wrapper_input Prepared input metadata.
+#'
+#' @return An integer vector indexing a non-missing result vector.
+#' @noRd
+build_normalized_structure_indices <- function(wrapper_input) {
+  indices <- rep(NA_integer_, wrapper_input$size)
+  indices[!wrapper_input$na_mask] <- match(
+    wrapper_input$non_na_x,
+    wrapper_input$unique_x
+  )
+  indices
+}
+
+
 #' Validate wrapper arguments.
 #'
 #' @param x A character vector of structure strings.

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -5,6 +5,8 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param validate Whether to validate parsed glycan graphs before constructing
+#'   the result.
 #' @param call The call to report in user-facing errors.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
@@ -14,12 +16,14 @@ struc_parser_wrapper <- function(
   parser,
   on_failure = "error",
   progress = FALSE,
+  validate = TRUE,
   call = rlang::caller_env()
 ) {
   on_failure <- validate_struc_parser_wrapper_args(
     x,
     on_failure,
     progress,
+    validate,
     call = call
   )
   wrapper_input <- prepare_struc_parser_input(x)
@@ -34,7 +38,8 @@ struc_parser_wrapper <- function(
   parsed_unique <- parse_unique_graphs(
     wrapper_input$unique_x,
     parser,
-    progress = progress
+    progress = progress,
+    validate = validate
   )
   abort_on_invalid_parse(
     parsed_unique$invalid_unique_x,
@@ -51,7 +56,8 @@ struc_parser_wrapper <- function(
 
   build_wrapped_structure(
     wrapper_input = wrapper_input,
-    parsed_unique = parsed_unique
+    parsed_unique = parsed_unique,
+    validate = validate
   )
 }
 
@@ -159,9 +165,16 @@ build_normalized_structure_indices <- function(wrapper_input) {
 #'
 #' @return The validated `on_failure` value.
 #' @noRd
-validate_struc_parser_wrapper_args <- function(x, on_failure, progress, call) {
+validate_struc_parser_wrapper_args <- function(
+  x,
+  on_failure,
+  progress,
+  validate = TRUE,
+  call
+) {
   checkmate::assert_character(x)
   checkmate::assert_flag(progress)
+  checkmate::assert_flag(validate)
   rlang::arg_match(
     on_failure,
     values = c("error", "na"),
@@ -198,7 +211,12 @@ prepare_struc_parser_input <- function(x) {
 #'
 #' @return A list containing valid and invalid unique parse results.
 #' @noRd
-parse_unique_graphs <- function(unique_x, parser, progress = FALSE) {
+parse_unique_graphs <- function(
+  unique_x,
+  parser,
+  progress = FALSE,
+  validate = TRUE
+) {
   safe_parse_one_graph <- purrr::possibly(
     parse_one_graph,
     otherwise = NA
@@ -207,6 +225,7 @@ parse_unique_graphs <- function(unique_x, parser, progress = FALSE) {
     unique_x,
     safe_parse_one_graph,
     parser = parser,
+    validate = validate,
     .progress = progress
   )
   invalid_mask <- purrr::map_lgl(parsed_unique_graphs, ~ identical(.x, NA))
@@ -241,9 +260,10 @@ abort_on_invalid_parse <- function(invalid_unique_x, on_failure, call) {
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
-build_wrapped_structure <- function(wrapper_input, parsed_unique) {
+build_wrapped_structure <- function(wrapper_input, parsed_unique, validate) {
   unique_result <- build_unique_wrapped_structure(
-    parsed_unique$valid_unique_graphs
+    parsed_unique$valid_unique_graphs,
+    validate = validate
   )
   result_indices <- build_wrapped_structure_indices(
     wrapper_input,
@@ -263,8 +283,13 @@ build_wrapped_structure <- function(wrapper_input, parsed_unique) {
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
-build_unique_wrapped_structure <- function(valid_unique_graphs) {
-  glyrepr::validate_glycan_graph_vector(valid_unique_graphs)
+build_unique_wrapped_structure <- function(
+  valid_unique_graphs,
+  validate = TRUE
+) {
+  if (validate) {
+    glyrepr::validate_glycan_graph_vector(valid_unique_graphs)
+  }
   iupacs <- purrr::map_chr(valid_unique_graphs, glyrepr::graph_to_iupac)
 
   unique_iupac <- !duplicated(unname(iupacs))
@@ -305,9 +330,11 @@ build_wrapped_structure_indices <- function(wrapper_input, parsed_unique) {
 #'
 #' @return A valid, canonical glycan graph.
 #' @noRd
-parse_one_graph <- function(x, parser) {
+parse_one_graph <- function(x, parser, validate = TRUE) {
   graph <- parser(x)
-  graph <- glyrepr::validate_glycan_graph(graph)
+  if (validate) {
+    graph <- glyrepr::validate_glycan_graph(graph)
+  }
   glyrepr::canonicalize_glycan_graph(graph)
 }
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -31,7 +31,7 @@ struc_parser_wrapper <- function(
     ))
   }
 
-  parsed_unique <- parse_unique_structures(
+  parsed_unique <- parse_unique_graphs(
     wrapper_input$unique_x,
     parser,
     progress = progress
@@ -96,7 +96,7 @@ prepare_struc_parser_input <- function(x) {
 }
 
 
-#' Parse unique input structures and separate failures.
+#' Parse, validate, and canonicalize unique input graphs.
 #'
 #' @param unique_x A character vector of unique, non-`NA` structure strings.
 #' @param parser A parser function that returns one glycan graph per string.
@@ -104,22 +104,22 @@ prepare_struc_parser_input <- function(x) {
 #'
 #' @return A list containing valid and invalid unique parse results.
 #' @noRd
-parse_unique_structures <- function(unique_x, parser, progress = FALSE) {
-  safe_parse_one_structure <- purrr::possibly(
-    parse_one_structure,
+parse_unique_graphs <- function(unique_x, parser, progress = FALSE) {
+  safe_parse_one_graph <- purrr::possibly(
+    parse_one_graph,
     otherwise = NA
   )
-  parsed_unique_structures <- purrr::map(
+  parsed_unique_graphs <- purrr::map(
     unique_x,
-    safe_parse_one_structure,
+    safe_parse_one_graph,
     parser = parser,
     .progress = progress
   )
-  invalid_mask <- purrr::map_lgl(parsed_unique_structures, ~ identical(.x, NA))
+  invalid_mask <- purrr::map_lgl(parsed_unique_graphs, ~ identical(.x, NA))
   list(
     invalid_unique_x = unique_x[invalid_mask],
     valid_unique_x = unique_x[!invalid_mask],
-    valid_unique_structures = parsed_unique_structures[!invalid_mask]
+    valid_unique_graphs = parsed_unique_graphs[!invalid_mask]
   )
 }
 
@@ -149,7 +149,7 @@ abort_on_invalid_parse <- function(invalid_unique_x, on_failure, call) {
 #' @noRd
 build_wrapped_structure <- function(wrapper_input, parsed_unique) {
   unique_result <- build_unique_wrapped_structure(
-    parsed_unique$valid_unique_structures
+    parsed_unique$valid_unique_graphs
   )
   result_indices <- build_wrapped_structure_indices(
     wrapper_input,
@@ -165,17 +165,19 @@ build_wrapped_structure <- function(wrapper_input, parsed_unique) {
 
 #' Build a glycan structure vector for unique parsed structures.
 #'
-#' @param valid_unique_structures A list of length-1 glycan structures.
+#' @param valid_unique_graphs A list of valid, canonical glycan graphs.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #' @noRd
-build_unique_wrapped_structure <- function(valid_unique_structures) {
-  valid_graphs <- purrr::map(
-    valid_unique_structures,
-    glyrepr::get_structure_graphs,
-    return_list = FALSE
-  )
-  do.call(glyrepr::glycan_structure, valid_graphs)
+build_unique_wrapped_structure <- function(valid_unique_graphs) {
+  glyrepr::validate_glycan_graph_vector(valid_unique_graphs)
+  iupacs <- purrr::map_chr(valid_unique_graphs, glyrepr::graph_to_iupac)
+
+  unique_iupac <- !duplicated(unname(iupacs))
+  unique_graphs <- valid_unique_graphs[unique_iupac]
+  names(unique_graphs) <- unname(iupacs[unique_iupac])
+
+  glyrepr::new_glycan_structure(iupacs, unique_graphs)
 }
 
 
@@ -202,15 +204,17 @@ build_wrapped_structure_indices <- function(wrapper_input, parsed_unique) {
 }
 
 
-#' Parse a single structure string into a validated glycan structure.
+#' Parse a single structure string into a valid, canonical graph.
 #'
 #' @param x A single structure string.
 #' @param parser A parser function that returns a glycan graph.
 #'
-#' @return A length-1 [glyrepr::glycan_structure()] object.
+#' @return A valid, canonical glycan graph.
 #' @noRd
-parse_one_structure <- function(x, parser) {
-  glyrepr::as_glycan_structure(list(parser(x)))
+parse_one_graph <- function(x, parser) {
+  graph <- parser(x)
+  graph <- glyrepr::validate_glycan_graph(graph)
+  glyrepr::canonicalize_glycan_graph(graph)
 }
 
 
@@ -222,10 +226,7 @@ parse_one_structure <- function(x, parser) {
 #' @return A [glyrepr::glycan_structure()] object filled with `NA`.
 #' @noRd
 make_na_glycan_structure <- function(n, names = NULL) {
-  result <- glyrepr::glycan_structure(NA)
-  result <- result[rep(1, n)]
-  if (!is.null(names)) {
-    attr(result, "names") <- names
-  }
-  result
+  iupacs <- rep(NA_character_, n)
+  attr(iupacs, "names") <- names
+  glyrepr::new_glycan_structure(iupacs)
 }

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -4,7 +4,7 @@
 \alias{parse_glycoct}
 \title{Parse GlycoCT Structures}
 \usage{
-parse_glycoct(x, on_failure = "error", progress = FALSE)
+parse_glycoct(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,9 @@ parse_glycoct(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_kcf.Rd
+++ b/man/parse_kcf.Rd
@@ -4,7 +4,7 @@
 \alias{parse_kcf}
 \title{Parse KCF Structures}
 \usage{
-parse_kcf(x, on_failure = "error", progress = FALSE)
+parse_kcf(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of KCF strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,9 @@ parse_kcf(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_linucs.Rd
+++ b/man/parse_linucs.Rd
@@ -4,7 +4,7 @@
 \alias{parse_linucs}
 \title{Parse LINUCS Structures}
 \usage{
-parse_linucs(x, on_failure = "error", progress = FALSE)
+parse_linucs(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of LINUCS strings. NA values are allowed and
@@ -14,6 +14,9 @@ will be returned as NA structures.}
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.
@@ -28,7 +31,7 @@ linkage token, a residue token, and a braced child list, for example
 LINUCS linkages are written as \code{"(parent+child)"}, where \code{parent} is the
 linkage position on the parent residue and \code{child} is the anomeric linkage
 position on the child residue. Residue labels are normalized to the
-monosaccharide and substituent vocabulary used by \link[glyrepr:glyrepr-package]{glyrepr::glyrepr}.
+monosaccharide and substituent vocabulary used by \link[glyrepr:glyrepr]{glyrepr::glyrepr}.
 }
 \examples{
 linucs <- "[][b-D-Glcp]{[(4+1)][b-D-Galp]{}}"

--- a/man/parse_pglyco_struc.Rd
+++ b/man/parse_pglyco_struc.Rd
@@ -4,7 +4,7 @@
 \alias{parse_pglyco_struc}
 \title{Parse pGlyco Structures}
 \usage{
-parse_pglyco_struc(x, on_failure = "error", progress = FALSE)
+parse_pglyco_struc(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,9 @@ parse_pglyco_struc(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_strucgp_struc.Rd
+++ b/man/parse_strucgp_struc.Rd
@@ -4,7 +4,7 @@
 \alias{parse_strucgp_struc}
 \title{Parse StrucGP Structures}
 \usage{
-parse_strucgp_struc(x, on_failure = "error", progress = FALSE)
+parse_strucgp_struc(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,9 @@ parse_strucgp_struc(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -4,7 +4,7 @@
 \alias{parse_wurcs}
 \title{Parse WURCS Structures}
 \usage{
-parse_wurcs(x, on_failure = "error", progress = FALSE)
+parse_wurcs(x, on_failure = "error", progress = FALSE, validate = TRUE)
 }
 \arguments{
 \item{x}{A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,9 @@ parse_wurcs(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{validate}{Whether to validate parsed glycan graphs before constructing
+the result.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/tests/testthat/test-parse-iupac-compact.R
+++ b/tests/testthat/test-parse-iupac-compact.R
@@ -41,6 +41,16 @@ test_that("IUPAC-compact preserves NA and name semantics", {
   )
 })
 
+test_that("IUPAC-compact vectorizes terminal anomer positions", {
+  expect_identical(
+    iupac_compact_default_anomer_pos(c("Glc", "Neu5Ac", "Hex")),
+    c("1", "2", "1")
+  )
+
+  parsed <- parse_iupac_compact(c("Glcb", "Neu5Aca"))
+  expect_identical(as.character(parsed), c("Glc(b1-", "Neu5Ac(a2-"))
+})
+
 test_that("IUPAC-compact supports on_failure handling", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-pglyco.R
+++ b/tests/testthat/test-parse-pglyco.R
@@ -24,3 +24,54 @@ test_that("pH and aH monosaccharides", {
   glycan <- parse_pglyco_struc("(pH(aH))")
   expect_snapshot(print(glycan, verbose = TRUE))
 })
+
+
+test_that("pGlyco graph assembly preserves branched topology", {
+  graph <- do_parse_pglyco_struc(
+    "(N(F)(N(H(H(N))(H(N(H))))))"
+  )
+
+  expect_identical(
+    igraph::as_edgelist(graph, names = FALSE),
+    matrix(
+      c(
+        1,
+        2,
+        1,
+        3,
+        3,
+        4,
+        4,
+        5,
+        5,
+        6,
+        4,
+        7,
+        7,
+        8,
+        8,
+        9
+      ),
+      ncol = 2,
+      byrow = TRUE
+    )
+  )
+  expect_identical(
+    igraph::vertex_attr(graph, "mono"),
+    c(
+      "HexNAc",
+      "dHex",
+      "HexNAc",
+      "Hex",
+      "Hex",
+      "HexNAc",
+      "Hex",
+      "HexNAc",
+      "Hex"
+    )
+  )
+  expect_identical(
+    igraph::edge_attr(graph, "linkage"),
+    rep("??-?", 8)
+  )
+})

--- a/tests/testthat/test-parse-strucgp.R
+++ b/tests/testthat/test-parse-strucgp.R
@@ -10,3 +10,54 @@ test_that("A2B2C1D1E1F1fedD1E1F1feE1F1fedcba", {
   glycan <- parse_strucgp_struc("A2B2C1D1E1F1fedD1E1F1feE1F1fedcba")
   expect_snapshot(print(glycan, verbose = TRUE))
 })
+
+
+test_that("StrucGP graph assembly preserves branched topology", {
+  graph <- do_parse_strucgp_struc(
+    "A2B2C1D1E2F1fedD1E2edcbB5ba"
+  )
+
+  expect_identical(
+    igraph::as_edgelist(graph, names = TRUE),
+    matrix(
+      c(
+        "1",
+        "2",
+        "2",
+        "3",
+        "3",
+        "4",
+        "4",
+        "5",
+        "5",
+        "6",
+        "3",
+        "7",
+        "7",
+        "8",
+        "1",
+        "9"
+      ),
+      ncol = 2,
+      byrow = TRUE
+    )
+  )
+  expect_identical(
+    igraph::vertex_attr(graph, "mono"),
+    c(
+      "HexNAc",
+      "HexNAc",
+      "Hex",
+      "Hex",
+      "HexNAc",
+      "Hex",
+      "Hex",
+      "HexNAc",
+      "dHex"
+    )
+  )
+  expect_identical(
+    igraph::edge_attr(graph, "linkage"),
+    rep("??-?", 8)
+  )
+})

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -36,13 +36,19 @@ test_that("struc_parser_wrapper parses each unique non-NA input once", {
   expect_equal(parser_calls, c("A", "B", "C"))
 })
 
-test_that("struc_parser_wrapper constructs each unique non-NA graph once", {
-  constructor_sizes <- integer()
-  original_glycan_structure <- glyrepr::glycan_structure
+test_that("struc_parser_wrapper checks each unique non-NA graph once", {
+  validation_calls <- 0L
+  canonicalization_calls <- 0L
+  original_validate <- glyrepr::validate_glycan_graph
+  original_canonicalize <- glyrepr::canonicalize_glycan_graph
   testthat::local_mocked_bindings(
-    glycan_structure = function(...) {
-      constructor_sizes <<- c(constructor_sizes, length(list(...)))
-      original_glycan_structure(...)
+    validate_glycan_graph = function(graph) {
+      validation_calls <<- validation_calls + 1L
+      original_validate(graph)
+    },
+    canonicalize_glycan_graph = function(graph) {
+      canonicalization_calls <<- canonicalization_calls + 1L
+      original_canonicalize(graph)
     },
     .package = "glyrepr"
   )
@@ -55,7 +61,42 @@ test_that("struc_parser_wrapper constructs each unique non-NA graph once", {
     as.character(result),
     c("HexNAc(??-", "Hex(??-", NA, "HexNAc(??-", "Hex(??-", "HexNAc(??-")
   )
-  expect_lte(max(constructor_sizes), length(unique(input[!is.na(input)])))
+  expect_equal(validation_calls, 2L)
+  expect_equal(canonicalization_calls, 2L)
+  expect_length(attr(result, "graphs"), 2L)
+})
+
+test_that("struc_parser_wrapper avoids high-level structure constructors", {
+  testthat::local_mocked_bindings(
+    as_glycan_structure = function(...) {
+      stop("Unexpected high-level construction")
+    },
+    glycan_structure = function(...) {
+      stop("Unexpected high-level construction")
+    },
+    .package = "glyrepr"
+  )
+
+  result <- parse_pglyco_struc(c("(N)", "(H)"))
+
+  expect_identical(as.character(result), c("HexNAc(??-", "Hex(??-"))
+})
+
+test_that("struc_parser_wrapper deduplicates equivalent parsed graphs", {
+  parser <- function(x) {
+    graph <- igraph::make_empty_graph(n = 1, directed = TRUE)
+    igraph::V(graph)$name <- "1"
+    igraph::V(graph)$mono <- "Hex"
+    igraph::V(graph)$sub <- ""
+    igraph::E(graph)$linkage <- character()
+    graph$anomer <- "??"
+    graph
+  }
+
+  result <- struc_parser_wrapper(c("first", "second"), parser)
+
+  expect_identical(as.character(result), rep("Hex(??-", 2))
+  expect_length(attr(result, "graphs"), 1L)
 })
 
 test_that("struc_parser_wrapper preserves order with duplicates", {

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -99,6 +99,58 @@ test_that("struc_parser_wrapper deduplicates equivalent parsed graphs", {
   expect_length(attr(result, "graphs"), 1L)
 })
 
+test_that("normalized parsers pass one complete unique vector to glyrepr", {
+  constructor_inputs <- list()
+  original_constructor <- glyrepr::as_glycan_structure
+  testthat::local_mocked_bindings(
+    as_glycan_structure = function(x, ...) {
+      constructor_inputs[[length(constructor_inputs) + 1L]] <<- x
+      original_constructor(x, ...)
+    },
+    .package = "glyrepr"
+  )
+
+  input <- c(
+    first = "Gal(b1-3)Glc(a1-",
+    second = "Glc(a1-",
+    duplicate = "Gal(b1-3)Glc(a1-",
+    missing = NA_character_
+  )
+  result <- parse_iupac_condensed(input)
+
+  expect_length(constructor_inputs, 1L)
+  expect_identical(
+    constructor_inputs[[1]],
+    c("Gal(b1-3)Glc(a1-", "Glc(a1-")
+  )
+  expect_identical(names(result), names(input))
+  expect_identical(
+    unname(as.character(result)),
+    c("Gal(b1-3)Glc(a1-", "Glc(a1-", "Gal(b1-3)Glc(a1-", NA_character_)
+  )
+})
+
+test_that("normalization wrapper vectorizes unique inputs", {
+  normalizer_inputs <- list()
+  normalizer <- function(x) {
+    normalizer_inputs[[length(normalizer_inputs) + 1L]] <<- x
+    dplyr::recode_values(
+      x,
+      "A" ~ "Gal(b1-3)Glc(a1-",
+      "B" ~ "Glc(a1-"
+    )
+  }
+
+  result <- normalized_struc_parser_wrapper(c("A", "B", "A"), normalizer)
+
+  expect_length(normalizer_inputs, 1L)
+  expect_identical(normalizer_inputs[[1]], c("A", "B"))
+  expect_identical(
+    as.character(result),
+    c("Gal(b1-3)Glc(a1-", "Glc(a1-", "Gal(b1-3)Glc(a1-")
+  )
+})
+
 test_that("struc_parser_wrapper preserves order with duplicates", {
   input <- c("(N)", "(H)", "(N)", "(F)", "(H)", "(N)")
   result <- parse_pglyco_struc(input)

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -66,6 +66,47 @@ test_that("struc_parser_wrapper checks each unique non-NA graph once", {
   expect_length(attr(result, "graphs"), 2L)
 })
 
+test_that("struc_parser_wrapper skips validation but canonicalizes trusted graphs", {
+  validation_calls <- 0L
+  canonicalization_calls <- 0L
+  original_canonicalize <- glyrepr::canonicalize_glycan_graph
+  testthat::local_mocked_bindings(
+    validate_glycan_graph = function(graph) {
+      validation_calls <<- validation_calls + 1L
+      graph
+    },
+    canonicalize_glycan_graph = function(graph) {
+      canonicalization_calls <<- canonicalization_calls + 1L
+      original_canonicalize(graph)
+    },
+    .package = "glyrepr"
+  )
+
+  result <- parse_pglyco_struc(c("(N)", "(H)", "(N)"), validate = FALSE)
+
+  expect_identical(
+    as.character(result),
+    c("HexNAc(??-", "Hex(??-", "HexNAc(??-")
+  )
+  expect_equal(validation_calls, 0L)
+  expect_equal(canonicalization_calls, 2L)
+})
+
+test_that("graph parsers expose validate", {
+  parsers <- c(
+    "parse_glycoct",
+    "parse_kcf",
+    "parse_linucs",
+    "parse_pglyco_struc",
+    "parse_strucgp_struc",
+    "parse_wurcs"
+  )
+
+  for (parser in parsers) {
+    expect_identical(formals(get(parser))$validate, TRUE, info = parser)
+  }
+})
+
 test_that("struc_parser_wrapper avoids high-level structure constructors", {
   testthat::local_mocked_bindings(
     as_glycan_structure = function(...) {

--- a/tests/testthat/test-struc-parser-wrapper.R
+++ b/tests/testthat/test-struc-parser-wrapper.R
@@ -18,3 +18,28 @@ test_that("struc_parser_wrapper returns glyrepr-compatible vectors", {
     NA
   )
 })
+
+test_that("struc_parser_wrapper treats invalid parsed graphs as failures", {
+  parser <- function(x) {
+    graph <- igraph::make_empty_graph(n = 1, directed = TRUE)
+    igraph::V(graph)$name <- "1"
+    igraph::V(graph)$mono <- "Hex"
+    igraph::V(graph)$sub <- ""
+    igraph::E(graph)$linkage <- character()
+    graph$anomer <- "??"
+
+    if (x == "invalid") {
+      graph <- igraph::as_undirected(graph)
+    }
+
+    graph
+  }
+
+  result <- struc_parser_wrapper(
+    c("valid", "invalid"),
+    parser,
+    on_failure = "na"
+  )
+
+  expect_identical(as.character(result), c("Hex(??-", NA_character_))
+})


### PR DESCRIPTION
## Summary

- Construct parser outputs through glyrepr's low-level graph APIs and batch normalized IUPAC construction.
- Preserve branched StrucGP and pGlyco graph topology during batched edge assembly.
- Add validate = TRUE/FALSE to graph-based parsers, with validation retained by default.

## Benchmark

50 documented inputs per parser; perf versus main with the default validation behavior.

| Parser | main | perf | Speedup |
| --- | ---: | ---: | ---: |
| IUPAC-condensed | 3.316 s | 1.571 s | 2.11x |
| IUPAC-compact | 3.360 s | 1.877 s | 1.79x |
| GLYCAM-IUPAC | 3.040 s | 1.710 s | 1.78x |
| GlycoCT | 5.078 s | 4.474 s | 1.14x |
| WURCS | 4.057 s | 2.646 s | 1.53x |

Valid-result counts matched main for all five workloads.

With the new trusted-input path, validate = FALSE was 1.27x faster for GlycoCT and 1.85x faster for WURCS. Validation remains the default: in the WURCS sample, skipping validation returned two additional results, so it is not behavior-equivalent for untrusted input.

## Verification

- devtools::test()
- git diff --check