### PR TITLE
perf: speed up GlycoCT and WURCS residue matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).
+* `parse_glycoct()` and `parse_wurcs()` now reuse indexed residue matching and cached classification to improve parsing performance (#37).
 
 # glyparse 0.7.1
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -282,11 +282,14 @@ parse_lin_section <- function(lin_lines) {
 }
 
 build_glycoct_graph <- function(residues, linkages) {
-  # Load monosaccharide mappings
-  mono_mappings <- load_mono_mappings()
+  mono_mapping_index <- glycoct_mapping_index()
 
   # Consolidate monosaccharides with their substituents
-  consolidated <- consolidate_residues(residues, linkages, mono_mappings)
+  consolidated <- consolidate_residues(
+    residues,
+    linkages,
+    mono_mapping_index
+  )
 
   # Build igraph
   if (length(consolidated$vertices) == 0) {
@@ -937,12 +940,189 @@ load_alditol_mono_mappings <- function() {
   return(GLYCOCT_ALDITOL_MAP)
 }
 
-consolidate_residues <- function(residues, linkages, mono_mappings) {
-  has_alditol <- has_glycoct_alditol_residue(residues)
-  alditol_mappings <- if (has_alditol) {
-    load_alditol_mono_mappings()
+compile_glycoct_mapping <- function(name, mapping) {
+  mono_lines <- mapping$res[grepl("^\\d+b:", mapping$res)]
+  pattern_mono <- NULL
+  if (length(mono_lines) > 0) {
+    pattern_mono <- sub("^\\d+b:[abxo]-", "", mono_lines[[1]])
+  }
+
+  sub_lines <- mapping$res[grepl("^\\d+s:", mapping$res)]
+  pattern_subs <- sort(sub("^\\d+s:", "", sub_lines))
+
+  pattern_linkages <- character()
+  if (!is.null(mapping$lin)) {
+    linkage_matches <- regexec(
+      "\\d+:(\\d+)[do]?\\((\\d+)\\+(\\d+)\\)(\\d+)[dn]?",
+      mapping$lin
+    )
+    linkage_parts <- regmatches(mapping$lin, linkage_matches)
+    pattern_linkages <- sort(vapply(
+      linkage_parts,
+      function(parts) {
+        if (length(parts) == 0) {
+          return(NA_character_)
+        }
+        paste0(parts[[3]], "+", parts[[4]])
+      },
+      character(1)
+    ))
+    pattern_linkages <- pattern_linkages[!is.na(pattern_linkages)]
+  }
+
+  c(
+    list(name = name),
+    glycoct_mono_signature(pattern_mono),
+    list(
+      subs = pattern_subs,
+      linkages = pattern_linkages,
+      single = length(mapping$res) == 1L
+    )
+  )
+}
+
+glycoct_mono_signature <- function(content) {
+  bounds <- extract_glycoct_ring_bounds(content)
+  list(
+    mono = content,
+    core = remove_glycoct_ring_bounds(content),
+    bounds = bounds,
+    wildcard_bounds = !is.na(bounds) && grepl("x", bounds, fixed = TRUE),
+    alditol = is_glycoct_alditol_mono(content)
+  )
+}
+
+glycoct_signature_mono_matches <- function(signature, entry) {
+  if (!identical(signature$alditol, entry$alditol)) {
+    return(FALSE)
+  }
+  if (is.na(signature$bounds) || is.na(entry$bounds)) {
+    return(identical(signature$bounds, entry$bounds))
+  }
+  identical(signature$bounds, entry$bounds) ||
+    signature$wildcard_bounds ||
+    entry$wildcard_bounds
+}
+
+glycoct_signature_key <- function(core, subs, linkages) {
+  paste(
+    core,
+    paste(subs, collapse = "\r"),
+    paste(linkages, collapse = "\r"),
+    sep = "\n"
+  )
+}
+
+compile_glycoct_mapping_index <- function(mappings) {
+  entries <- Map(
+    compile_glycoct_mapping,
+    names(mappings),
+    unname(mappings)
+  )
+  cores <- vapply(entries, `[[`, character(1), "core")
+  keys <- vapply(
+    entries,
+    function(entry) {
+      glycoct_signature_key(
+        entry$core,
+        entry$subs,
+        entry$linkages
+      )
+    },
+    character(1)
+  )
+
+  list(
+    entries = entries,
+    exact = split(seq_along(entries), keys),
+    by_core = split(seq_along(entries), cores)
+  )
+}
+
+glycoct_mapping_index <- local({
+  regular <- NULL
+  alditol_index <- NULL
+
+  function(alditol = FALSE) {
+    if (alditol) {
+      if (is.null(alditol_index)) {
+        alditol_index <<- compile_glycoct_mapping_index(
+          load_alditol_mono_mappings()
+        )
+      }
+      return(alditol_index)
+    }
+
+    if (is.null(regular)) {
+      regular <<- compile_glycoct_mapping_index(load_mono_mappings())
+    }
+    regular
+  }
+})
+
+glycoct_group_signature <- function(group, residues, linkages) {
+  group_mono <- NULL
+  group_subs <- character()
+  group_linkages <- character()
+
+  for (id in group) {
+    res <- residues[[as.character(id)]]
+    if (is.null(res)) {
+      next
+    }
+    if (res$type == "mono") {
+      group_mono <- res$content
+    } else if (res$type == "sub") {
+      group_subs <- c(group_subs, res$content)
+    }
+  }
+
+  for (linkage in linkages) {
+    if (!(linkage$from_res %in% group && linkage$to_res %in% group)) {
+      next
+    }
+    from_res <- residues[[as.character(linkage$from_res)]]
+    to_res <- residues[[as.character(linkage$to_res)]]
+    if (
+      !is.null(from_res) &&
+        !is.null(to_res) &&
+        from_res$type == "mono" &&
+        to_res$type == "sub"
+    ) {
+      group_linkages <- c(
+        group_linkages,
+        paste0(linkage$from_pos, "+", linkage$to_pos)
+      )
+    }
+  }
+
+  mono_signature <- if (is.null(group_mono)) {
+    list(
+      mono = NULL,
+      core = NULL,
+      bounds = NA_character_,
+      wildcard_bounds = FALSE,
+      alditol = FALSE
+    )
   } else {
-    list()
+    glycoct_mono_signature(group_mono)
+  }
+
+  c(
+    mono_signature,
+    list(
+      subs = sort(group_subs),
+      linkages = sort(group_linkages)
+    )
+  )
+}
+
+consolidate_residues <- function(residues, linkages, mono_mapping_index) {
+  has_alditol <- has_glycoct_alditol_residue(residues)
+  alditol_mapping_index <- if (has_alditol) {
+    glycoct_mapping_index(alditol = TRUE)
+  } else {
+    NULL
   }
 
   # Group residues by their linkage relationships to identify composite structures
@@ -970,19 +1150,21 @@ consolidate_residues <- function(residues, linkages, mono_mappings) {
         )
       }
     } else {
-      # Composite structure - try to match with known patterns
-      matched <- match_composite_structure(
+      group_signature <- glycoct_group_signature(
         group,
         residues,
-        linkages,
-        alditol_mappings
+        linkages
+      )
+
+      # Composite structure - try to match with known patterns
+      matched <- match_composite_structure(
+        group_signature,
+        alditol_mapping_index
       )
       if (is.null(matched)) {
         matched <- match_composite_structure(
-          group,
-          residues,
-          linkages,
-          mono_mappings
+          group_signature,
+          mono_mapping_index
         )
       }
 
@@ -1014,16 +1196,17 @@ consolidate_residues <- function(residues, linkages, mono_mappings) {
           )
         } else {
           # No exact match - try partial matching with extra substituents
-          partial_mappings <- if (isTRUE(main_mono$is_alditol)) {
-            alditol_mappings
+          partial_mapping_index <- if (isTRUE(main_mono$is_alditol)) {
+            alditol_mapping_index
           } else {
-            mono_mappings
+            mono_mapping_index
           }
           partial_result <- match_partial_composite_structure(
             group,
             residues,
             linkages,
-            partial_mappings
+            group_signature,
+            partial_mapping_index
           )
           vertices <- append(
             vertices,
@@ -1090,28 +1273,39 @@ find_composite_groups <- function(residues, linkages) {
 }
 
 match_composite_structure <- function(
-  group,
-  residues,
-  linkages,
-  mono_mappings
+  group_signature,
+  mapping_index
 ) {
-  # Try to match the composite structure with known monosaccharides
-  for (idx in seq_along(mono_mappings)) {
-    mono_name <- names(mono_mappings)[[idx]]
-    mapping <- mono_mappings[[idx]]
-    if (matches_glycoct_pattern(group, residues, linkages, mapping)) {
-      return(mono_name)
+  if (is.null(mapping_index) || is.null(group_signature$core)) {
+    return(NULL)
+  }
+
+  key <- glycoct_signature_key(
+    group_signature$core,
+    group_signature$subs,
+    group_signature$linkages
+  )
+  candidates <- mapping_index$exact[[key]]
+  if (is.null(candidates)) {
+    return(NULL)
+  }
+
+  for (idx in candidates) {
+    entry <- mapping_index$entries[[idx]]
+    if (glycoct_signature_mono_matches(group_signature, entry)) {
+      return(entry$name)
     }
   }
 
-  return(NULL)
+  NULL
 }
 
 match_partial_composite_structure <- function(
   group,
   residues,
   linkages,
-  mono_mappings
+  group_signature,
+  mapping_index
 ) {
   generic_result <- match_generic_glycoct_composite(group, residues, linkages)
   if (!is.null(generic_result)) {
@@ -1121,75 +1315,47 @@ match_partial_composite_structure <- function(
   # Try to find the best partial match and identify extra substituents
   best_match <- NULL
   best_extra_subs <- c()
+  group_subs <- group_signature$subs
+  group_mono <- group_signature$mono
 
-  # Get all substituents in this group
-  group_subs <- c()
-  group_mono <- NULL
-
-  for (id in group) {
-    res <- residues[[as.character(id)]]
-    if (!is.null(res)) {
-      if (res$type == "mono") {
-        group_mono <- res
-      } else if (res$type == "sub") {
-        group_subs <- c(group_subs, res$content)
-      }
-    }
+  candidate_indices <- if (
+    is.null(mapping_index) || is.null(group_signature$core)
+  ) {
+    integer()
+  } else {
+    mapping_index$by_core[[group_signature$core]]
   }
 
   # Try to find a known composite that uses a subset of our substituents
-  for (idx in seq_along(mono_mappings)) {
-    mono_name <- names(mono_mappings)[[idx]]
-    mapping <- mono_mappings[[idx]]
-
-    # Get the pattern's substituents
-    pattern_subs <- c()
-    for (res_line in mapping$res) {
-      if (stringr::str_detect(res_line, "^\\d+s:")) {
-        sub_content <- stringr::str_remove(res_line, "^\\d+s:")
-        pattern_subs <- c(pattern_subs, sub_content)
-      }
-    }
+  for (idx in candidate_indices) {
+    entry <- mapping_index$entries[[idx]]
+    pattern_subs <- entry$subs
 
     # Check if pattern substituents are a subset of group substituents
     if (length(pattern_subs) > 0 && all(pattern_subs %in% group_subs)) {
-      # Get the pattern's monosaccharide
-      mono_lines <- mapping$res[stringr::str_detect(mapping$res, "^\\d+b:")]
-      if (length(mono_lines) > 0) {
-        pattern_mono_content <- stringr::str_remove(
-          mono_lines[1],
-          "^\\d+b:[abxo]-"
-        )
+      if (
+        !is.null(group_mono) &&
+          glycoct_signature_mono_matches(group_signature, entry)
+      ) {
+        exact_match <- identical(pattern_subs, group_signature$subs) &&
+          identical(entry$linkages, group_signature$linkages)
+        if (exact_match) {
+          next
+        }
 
-        # Check if monosaccharide matches
-        if (
-          !is.null(group_mono) &&
-            glycoct_mono_content_matches(
-              group_mono$content,
-              pattern_mono_content
+        # For partial matching, only consider if there are extra substituents
+        if (length(pattern_subs) < length(group_subs)) {
+          extra_subs <- setdiff(group_subs, pattern_subs)
+
+          if (
+            is.null(best_match) ||
+              length(pattern_subs) > length(best_match$pattern_subs)
+          ) {
+            best_match <- list(
+              mono_name = entry$name,
+              pattern_subs = pattern_subs
             )
-        ) {
-          # Verify that the pattern substituents actually match with correct linkages
-          # by using the full pattern matching function
-          if (matches_glycoct_pattern(group, residues, linkages, mapping)) {
-            # Exact match - shouldn't be in partial matching function
-            next
-          }
-
-          # For partial matching, only consider if there are extra substituents
-          if (length(pattern_subs) < length(group_subs)) {
-            extra_subs <- setdiff(group_subs, pattern_subs)
-
-            if (
-              is.null(best_match) ||
-                length(pattern_subs) > length(best_match$pattern_subs)
-            ) {
-              best_match <- list(
-                mono_name = mono_name,
-                pattern_subs = pattern_subs
-              )
-              best_extra_subs <- extra_subs
-            }
+            best_extra_subs <- extra_subs
           }
         }
       }
@@ -1212,7 +1378,7 @@ match_partial_composite_structure <- function(
   } else {
     # No partial match found, return base monosaccharide with all substituents
     if (!is.null(group_mono)) {
-      base_mono <- map_single_mono(group_mono$content)
+      base_mono <- map_single_mono(group_mono)
       formatted_subs <- format_extra_substituents(
         group_subs,
         group,
@@ -1562,22 +1728,18 @@ map_single_mono <- function(content) {
   # Extract monosaccharide name from content like "dglc-HEX-1:5" or "lgal-HEX-1:5|6:d"
 
   is_alditol <- is_glycoct_alditol_mono(content)
-  mono_mappings <- if (is_alditol) {
-    load_alditol_mono_mappings()
-  } else {
-    load_mono_mappings()
-  }
-  for (idx in seq_along(mono_mappings)) {
-    mono_name <- names(mono_mappings)[[idx]]
-    mapping <- mono_mappings[[idx]]
-    if (length(mapping$res) == 1) {
-      # Single monosaccharide without substituents
-      mono_line <- mapping$res[[1]]
-      if (stringr::str_detect(mono_line, "^\\d+b:")) {
-        pattern_content <- stringr::str_remove(mono_line, "^\\d+b:[abxo]-")
-        if (glycoct_mono_content_matches(content, pattern_content)) {
-          return(mono_name)
-        }
+  mapping_index <- glycoct_mapping_index(alditol = is_alditol)
+  mono_signature <- glycoct_mono_signature(content)
+  candidates <- mapping_index$by_core[[mono_signature$core]]
+  if (!is.null(candidates)) {
+    for (idx in candidates) {
+      entry <- mapping_index$entries[[idx]]
+      if (
+        entry$single &&
+          length(entry$subs) == 0L &&
+          glycoct_signature_mono_matches(mono_signature, entry)
+      ) {
+        return(entry$name)
       }
     }
   }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -30,9 +30,17 @@ parse_wurcs <- function(
   progress = FALSE,
   validate = TRUE
 ) {
+  residue_cache <- NULL
+  parser <- function(value) {
+    if (is.null(residue_cache)) {
+      residue_cache <<- build_wurcs_residue_cache(x)
+    }
+    do_parse_wurcs(value, residue_cache = residue_cache)
+  }
+
   struc_parser_wrapper(
     x,
-    do_parse_wurcs,
+    parser,
     on_failure = on_failure,
     progress = progress,
     validate = validate
@@ -407,6 +415,43 @@ WURCS_SUB_REGEX <- c(
   "N" = "N"
 )
 
+wurcs_regex_prefixes <- function(patterns) {
+  patterns <- sub("^\\^", "", patterns)
+  prefixes <- regmatches(
+    patterns,
+    regexpr("^[A-Za-z0-9_-]+", patterns)
+  )
+  prefixes[prefixes == ""] <- NA_character_
+  prefixes
+}
+
+WURCS_MONO_PREFIXES <- wurcs_regex_prefixes(WURCS_MONO_REGEX)
+WURCS_UNKNOWN_RING_MONO_PREFIXES <- wurcs_regex_prefixes(
+  WURCS_UNKNOWN_RING_MONO_REGEX
+)
+WURCS_ALDITOL_MONO_PREFIXES <- wurcs_regex_prefixes(
+  WURCS_ALDITOL_MONO_REGEX
+)
+WURCS_AMBIGUOUS_MONO_PREFIXES <- wurcs_regex_prefixes(
+  WURCS_AMBIGUOUS_MONO_REGEX
+)
+
+detect_wurcs_pattern <- function(residue, patterns, prefixes) {
+  candidates <- which(
+    is.na(prefixes) |
+      startsWith(residue, prefixes)
+  )
+  if (length(candidates) == 0L) {
+    candidates <- seq_along(patterns)
+  }
+
+  matched <- which(stringr::str_detect(residue, patterns[candidates]))
+  if (length(matched) == 0L) {
+    return(0L)
+  }
+  candidates[[matched[[1L]]]]
+}
+
 
 #' Detect whether a WURCS residue is an alditol descriptor.
 #'
@@ -415,11 +460,12 @@ WURCS_SUB_REGEX <- c(
 #' @return A logical scalar.
 #' @noRd
 is_wurcs_alditol_residue <- function(residue) {
-  purrr::detect_index(
+  detect_wurcs_pattern(
+    residue,
     WURCS_ALDITOL_MONO_REGEX,
-    ~ stringr::str_detect(residue, .x)
+    WURCS_ALDITOL_MONO_PREFIXES
   ) >
-    0
+    0L
 }
 
 
@@ -490,7 +536,7 @@ wurcs_anomer_pos <- function(mono) {
 }
 
 
-parse_residue <- function(residue) {
+parse_residue_details <- function(residue) {
   # This function accepts a WURCS residue (something in "[]"),
   # and returns a named vector of c(mono, anomer, sub)
   # `mono`: the IUPAC monosaccharide name
@@ -501,14 +547,16 @@ parse_residue <- function(residue) {
   is_alditol <- FALSE
 
   # Get monosaacharide name
-  mono_idx <- purrr::detect_index(
+  mono_idx <- detect_wurcs_pattern(
+    residue,
     WURCS_MONO_REGEX,
-    ~ stringr::str_detect(residue, .x)
+    WURCS_MONO_PREFIXES
   )
   if (mono_idx == 0) {
-    unknown_ring_mono_idx <- purrr::detect_index(
+    unknown_ring_mono_idx <- detect_wurcs_pattern(
+      residue,
       WURCS_UNKNOWN_RING_MONO_REGEX,
-      ~ stringr::str_detect(residue, .x)
+      WURCS_UNKNOWN_RING_MONO_PREFIXES
     )
     if (unknown_ring_mono_idx > 0) {
       mono <- names(WURCS_UNKNOWN_RING_MONO_REGEX)[[unknown_ring_mono_idx]]
@@ -520,9 +568,10 @@ parse_residue <- function(residue) {
         stringr::str_sub(anomer, 1, 1)
       )
     } else {
-      alditol_mono_idx <- purrr::detect_index(
+      alditol_mono_idx <- detect_wurcs_pattern(
+        residue,
         WURCS_ALDITOL_MONO_REGEX,
-        ~ stringr::str_detect(residue, .x)
+        WURCS_ALDITOL_MONO_PREFIXES
       )
       if (alditol_mono_idx > 0) {
         mono <- names(WURCS_ALDITOL_MONO_REGEX)[[alditol_mono_idx]]
@@ -530,9 +579,10 @@ parse_residue <- function(residue) {
         anomer <- paste0("?", wurcs_anomer_pos(mono))
         is_alditol <- TRUE
       } else {
-        ambiguous_mono_idx <- purrr::detect_index(
+        ambiguous_mono_idx <- detect_wurcs_pattern(
+          residue,
           WURCS_AMBIGUOUS_MONO_REGEX,
-          ~ stringr::str_detect(residue, .x)
+          WURCS_AMBIGUOUS_MONO_PREFIXES
         )
         if (ambiguous_mono_idx == 0) {
           cli::cli_abort("Unable to parse residue: {.str {residue}}")
@@ -632,7 +682,14 @@ parse_residue <- function(residue) {
     sub <- paste(substituents, collapse = ",")
   }
 
-  c(mono = mono, anomer = anomer, sub = sub)
+  list(
+    value = c(mono = mono, anomer = anomer, sub = sub),
+    alditol = is_alditol
+  )
+}
+
+parse_residue <- function(residue) {
+  parse_residue_details(residue)$value
 }
 
 
@@ -648,11 +705,56 @@ extract_wurcs_residues <- function(x) {
 }
 
 
-parse_unique_residues <- function(x) {
+build_wurcs_residue_cache <- function(x) {
+  descriptors <- stringr::str_extract_all(
+    x[!is.na(x)],
+    "\\[.*?\\]"
+  )
+  descriptors <- unique(unlist(descriptors, use.names = FALSE))
+  descriptors <- stringr::str_sub(descriptors, 2, -2)
+  details <- lapply(descriptors, function(descriptor) {
+    tryCatch(
+      parse_residue_details(descriptor),
+      error = identity
+    )
+  })
+  list(descriptors = descriptors, details = details)
+}
+
+get_wurcs_residue_details <- function(descriptor, residue_cache = NULL) {
+  if (is.null(residue_cache)) {
+    return(parse_residue_details(descriptor))
+  }
+
+  index <- match(descriptor, residue_cache$descriptors)
+  if (is.na(index)) {
+    return(parse_residue_details(descriptor))
+  }
+
+  details <- residue_cache$details[[index]]
+  if (inherits(details, "error")) {
+    stop(details)
+  }
+  details
+}
+
+parse_unique_residue_details <- function(x, residue_cache = NULL) {
+  residues <- extract_wurcs_residues(x)
+  details <- lapply(
+    residues,
+    get_wurcs_residue_details,
+    residue_cache = residue_cache
+  )
+  list(
+    values = lapply(details, `[[`, "value"),
+    has_alditol = any(vapply(details, `[[`, logical(1), "alditol"))
+  )
+}
+
+parse_unique_residues <- function(x, residue_cache = NULL) {
   # Input: a string of WURCS unique residues part
   # Output: a list of named vectors, each vector contains `mono`, `anomer`, and `sub`
-  residues <- extract_wurcs_residues(x)
-  purrr::map(residues, parse_residue)
+  parse_unique_residue_details(x, residue_cache)$values
 }
 
 
@@ -768,7 +870,7 @@ build_glycan_graph <- function(edgelist_df, vertex_df) {
 }
 
 
-do_parse_wurcs <- function(x) {
+do_parse_wurcs <- function(x, residue_cache = NULL) {
   wurcs_regex <- stringr::regex(
     "
     ^WURCS=2\\.0         # WURCS version
@@ -788,11 +890,12 @@ do_parse_wurcs <- function(x) {
   # unique_residues: a list of named character vectors,
   # each vector contains `mono` ("GlcNAc"), `anomer` ("b1"), and `sub` ("3Me")
   unique_residue_part <- stringr::str_extract(x, wurcs_regex, group = 1)
-  unique_residue_descriptors <- extract_wurcs_residues(unique_residue_part)
-  unique_residues <- parse_unique_residues(unique_residue_part)
-  if (
-    any(purrr::map_lgl(unique_residue_descriptors, is_wurcs_alditol_residue))
-  ) {
+  residue_details <- parse_unique_residue_details(
+    unique_residue_part,
+    residue_cache = residue_cache
+  )
+  unique_residues <- residue_details$values
+  if (residue_details$has_alditol) {
     warn_wurcs_alditol()
   }
 

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -283,6 +283,22 @@ test_that("GlycoCT matches amino sugars with unknown ring bounds", {
   expect_equal(as.character(parse_glycoct(glycoct)), "GlcN(??-")
 })
 
+test_that("GlycoCT mapping signatures index exact composite candidates", {
+  signature <- c(
+    glycoct_mono_signature("dglc-HEX-x:x"),
+    list(subs = "n-acetyl", linkages = "2+1")
+  )
+  mapping_index <- glycoct_mapping_index()
+
+  expect_identical(
+    match_composite_structure(signature, mapping_index),
+    "GlcNAc"
+  )
+
+  signature$linkages <- "5+1"
+  expect_null(match_composite_structure(signature, mapping_index))
+})
+
 test_that("GlycoCT handles N-sulfated amino sugars with unknown ring bounds", {
   glycoct <- paste0(
     "RES\n",

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1121,6 +1121,24 @@ test_that("glycan with only one monosacharide", {
   expect_snapshot(parse_wurcs(wurcs))
 })
 
+test_that("parse_wurcs parses shared residue descriptors once per call", {
+  parsed_descriptors <- character()
+  original_parse <- parse_residue_details
+  testthat::local_mocked_bindings(
+    parse_residue_details = function(residue) {
+      parsed_descriptors <<- c(parsed_descriptors, residue)
+      original_parse(residue)
+    }
+  )
+
+  parse_wurcs(c(
+    "WURCS=2.0/1,1,0/[a2122h-1a_1-5]/1/",
+    "WURCS=2.0/1,2,1/[a2122h-1a_1-5]/1-1/a1-b1"
+  ))
+
+  expect_identical(parsed_descriptors, "a2122h-1a_1-5")
+})
+
 
 # A basic example
 test_that("N-glycan core", {


### PR DESCRIPTION
## Summary

- Index GlycoCT mapping tables by invariant descriptor signatures while preserving ordered regex fallback behavior.
- Cache WURCS residue classification across batch inputs and prefilter ordered regex tables by descriptor prefix.
- Add regression coverage for GlycoCT matching precedence and shared WURCS residue descriptors.
- Document the parser performance improvements in the development NEWS entry (#37).

## Performance

- GlycoCT public parsing improved by 3.83x, with a 12.33x improvement on the composite-heavy matching benchmark.
- WURCS public parsing improved by 2.15x on the warm median, while residue classification improved by 2.8x.
- The WURCS benchmark reduced classifications from 1,227 descriptor occurrences to 32 unique descriptors.

## Verification

- Public parser values and graph signatures are identical to the baseline.
- `devtools::test()` passes all 1,074 tests.
- `devtools::check(error_on = "warning", cran = FALSE)` completes with 0 errors, warnings, or notes.
- `git diff --check` passes.