### PR TITLE
feat: add option to drop generic glycans

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     checkmate,
     cli,
     dplyr,
-    glyrepr (>= 0.14.0),
+    glyrepr (>= 0.14.0.9000),
     igraph,
     purrr (>= 1.0.0),
     rlang,
@@ -35,3 +35,5 @@ Depends:
 VignetteBuilder: knitr
 BugReports: https://github.com/glycoverse/glyparse/issues
 RoxygenNote: 7.3.3
+Remotes:  
+    glycoverse/glyrepr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyparse (development version)
 
+* `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -23,6 +23,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -42,13 +45,15 @@
 auto_parse <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   struc_parser_wrapper(
     x,
     do_auto_parse,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -20,6 +20,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -33,13 +36,15 @@
 parse_glycam_iupac <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     convert_glycam_iupac_to_condensed,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -23,6 +23,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -43,13 +46,15 @@ parse_glycoct <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   on_failure <- validate_struc_parser_wrapper_args(
     x,
     on_failure,
     progress,
     validate,
+    drop_generic,
     call = rlang::caller_env()
   )
   has_und <- purrr::map_lgl(
@@ -69,7 +74,8 @@ parse_glycoct <- function(
     do_parse_glycoct,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -17,6 +17,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -30,13 +33,15 @@
 parse_iupac_compact <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     convert_iupac_compact_to_condensed,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-iupac-condensed.R
+++ b/R/parse-iupac-condensed.R
@@ -25,6 +25,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -38,12 +41,14 @@
 parse_iupac_condensed <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -7,6 +7,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @details
 #' The function accepts both a Unicode format (using the Greek letters alpha/beta
@@ -28,13 +31,15 @@
 parse_iupac_extended <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     function(x) convert_ext_to_con(normalize_iupac_extended(x)),
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-iupac-short.R
+++ b/R/parse-iupac-short.R
@@ -18,6 +18,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -31,13 +34,15 @@
 parse_iupac_short <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     convert_short_to_condensed,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-kcf.R
+++ b/R/parse-kcf.R
@@ -9,6 +9,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -37,14 +40,16 @@ parse_kcf <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   struc_parser_wrapper(
     x,
     do_parse_kcf,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -7,6 +7,9 @@
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
 #'   structure cannot be parsed. `"na"` returns `NA` at invalid positions.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -18,13 +21,15 @@
 parse_linear_code <- function(
   x,
   on_failure = "error",
-  progress = FALSE
+  progress = FALSE,
+  drop_generic = FALSE
 ) {
   normalized_struc_parser_wrapper(
     x,
     convert_linear_to_iupac,
     on_failure = on_failure,
-    progress = progress
+    progress = progress,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -18,6 +18,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -30,14 +33,16 @@ parse_linucs <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   struc_parser_wrapper(
     x,
     do_parse_linucs,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-pglyco.R
+++ b/R/parse-pglyco.R
@@ -9,6 +9,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -21,14 +24,16 @@ parse_pglyco_struc <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   struc_parser_wrapper(
     x,
     do_parse_pglyco_struc,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-strucgp.R
+++ b/R/parse-strucgp.R
@@ -9,6 +9,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -21,14 +24,16 @@ parse_strucgp_struc <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   struc_parser_wrapper(
     x,
     do_parse_strucgp_struc,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -12,6 +12,9 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`. A
+#'   message reports the number replaced. By default, mixing generic and
+#'   concrete glycans raises an error.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
 #'
@@ -28,7 +31,8 @@ parse_wurcs <- function(
   x,
   on_failure = "error",
   progress = FALSE,
-  validate = TRUE
+  validate = TRUE,
+  drop_generic = FALSE
 ) {
   residue_cache <- NULL
   parser <- function(value) {
@@ -43,7 +47,8 @@ parse_wurcs <- function(
     parser,
     on_failure = on_failure,
     progress = progress,
-    validate = validate
+    validate = validate,
+    drop_generic = drop_generic
   )
 }
 

--- a/R/struc-parser-wrapper.R
+++ b/R/struc-parser-wrapper.R
@@ -7,6 +7,7 @@
 #' @param progress Whether to show a progress bar while parsing.
 #' @param validate Whether to validate parsed glycan graphs before constructing
 #'   the result.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`.
 #' @param call The call to report in user-facing errors.
 #'
 #' @return A [glyrepr::glycan_structure()] object.
@@ -17,6 +18,7 @@ struc_parser_wrapper <- function(
   on_failure = "error",
   progress = FALSE,
   validate = TRUE,
+  drop_generic = FALSE,
   call = rlang::caller_env()
 ) {
   on_failure <- validate_struc_parser_wrapper_args(
@@ -24,6 +26,7 @@ struc_parser_wrapper <- function(
     on_failure,
     progress,
     validate,
+    drop_generic,
     call = call
   )
   wrapper_input <- prepare_struc_parser_input(x)
@@ -46,6 +49,12 @@ struc_parser_wrapper <- function(
     on_failure,
     call = call
   )
+  if (drop_generic) {
+    parsed_unique <- drop_generic_parsed_graphs(
+      wrapper_input,
+      parsed_unique
+    )
+  }
 
   if (length(parsed_unique$valid_unique_x) == 0) {
     return(make_na_glycan_structure(
@@ -76,12 +85,14 @@ normalized_struc_parser_wrapper <- function(
   normalizer = identity,
   on_failure = "error",
   progress = FALSE,
+  drop_generic = FALSE,
   call = rlang::caller_env()
 ) {
   on_failure <- validate_struc_parser_wrapper_args(
     x,
     on_failure,
     progress,
+    drop_generic = drop_generic,
     call = call
   )
   wrapper_input <- prepare_struc_parser_input(x)
@@ -98,6 +109,27 @@ normalized_struc_parser_wrapper <- function(
     normalizer,
     progress = progress
   )
+  if (drop_generic) {
+    abort_on_invalid_parse(
+      wrapper_input$unique_x[is.na(normalized_unique)],
+      on_failure,
+      call = call
+    )
+    normalized_x <- normalized_unique[
+      build_normalized_structure_indices(wrapper_input)
+    ]
+    if (!is.null(wrapper_input$names)) {
+      attr(normalized_x, "names") <- wrapper_input$names
+    }
+    return(struc_parser_wrapper(
+      normalized_x,
+      do_parse_iupac_condensed,
+      on_failure = on_failure,
+      progress = progress,
+      drop_generic = TRUE,
+      call = call
+    ))
+  }
   unique_result <- suppressWarnings(glyrepr::as_glycan_structure(
     normalized_unique,
     on_failure = "na"
@@ -161,6 +193,7 @@ build_normalized_structure_indices <- function(wrapper_input) {
 #' @param x A character vector of structure strings.
 #' @param on_failure How to handle parsing failures.
 #' @param progress Whether to show a progress bar while parsing.
+#' @param drop_generic Whether to replace parsed generic glycans with `NA`.
 #' @param call The call to report in user-facing errors.
 #'
 #' @return The validated `on_failure` value.
@@ -170,16 +203,48 @@ validate_struc_parser_wrapper_args <- function(
   on_failure,
   progress,
   validate = TRUE,
+  drop_generic = FALSE,
   call
 ) {
   checkmate::assert_character(x)
   checkmate::assert_flag(progress)
   checkmate::assert_flag(validate)
+  checkmate::assert_flag(drop_generic)
   rlang::arg_match(
     on_failure,
     values = c("error", "na"),
     error_call = call
   )
+}
+
+
+#' Replace parsed generic glycans with missing values.
+#'
+#' @param wrapper_input Prepared input metadata.
+#' @param parsed_unique Parsed valid unique structures.
+#'
+#' @return `parsed_unique` without generic structures.
+#' @noRd
+drop_generic_parsed_graphs <- function(wrapper_input, parsed_unique) {
+  mono_types <- purrr::map_chr(
+    parsed_unique$valid_unique_graphs,
+    glyrepr::get_mono_type
+  )
+  generic_mask <- mono_types == "generic"
+  if (!any(generic_mask)) {
+    return(parsed_unique)
+  }
+
+  generic_unique_x <- parsed_unique$valid_unique_x[generic_mask]
+  n_generic <- sum(wrapper_input$non_na_x %in% generic_unique_x)
+  cli::cli_inform(
+    "Dropped {n_generic} generic glycan{?s} (replaced with {.code NA})."
+  )
+
+  parsed_unique$valid_unique_x <- parsed_unique$valid_unique_x[!generic_mask]
+  parsed_unique$valid_unique_graphs <-
+    parsed_unique$valid_unique_graphs[!generic_mask]
+  parsed_unique
 }
 
 

--- a/man/auto_parse.Rd
+++ b/man/auto_parse.Rd
@@ -4,7 +4,7 @@
 \alias{auto_parse}
 \title{Automatic Structure Parsing}
 \usage{
-auto_parse(x, on_failure = "error", progress = FALSE)
+auto_parse(x, on_failure = "error", progress = FALSE, drop_generic = FALSE)
 }
 \arguments{
 \item{x}{A character vector of structure strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +13,10 @@ auto_parse(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_glycam_iupac.Rd
+++ b/man/parse_glycam_iupac.Rd
@@ -4,7 +4,12 @@
 \alias{parse_glycam_iupac}
 \title{Parse GlyCAM IUPAC Structures}
 \usage{
-parse_glycam_iupac(x, on_failure = "error", progress = FALSE)
+parse_glycam_iupac(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of GlyCAM IUPAC strings. NA values are allowed
@@ -14,6 +19,10 @@ and will be returned as NA structures.}
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -4,7 +4,13 @@
 \alias{parse_glycoct}
 \title{Parse GlycoCT Structures}
 \usage{
-parse_glycoct(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_glycoct(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of GlycoCT strings. NA values are allowed and will be returned as NA structures.}
@@ -16,6 +22,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_compact.Rd
+++ b/man/parse_iupac_compact.Rd
@@ -4,7 +4,12 @@
 \alias{parse_iupac_compact}
 \title{Parse IUPAC-compact Structures}
 \usage{
-parse_iupac_compact(x, on_failure = "error", progress = FALSE)
+parse_iupac_compact(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-compact strings. NA values are allowed
@@ -14,6 +19,10 @@ and will be returned as NA structures.}
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_condensed.Rd
+++ b/man/parse_iupac_condensed.Rd
@@ -4,7 +4,12 @@
 \alias{parse_iupac_condensed}
 \title{Parse IUPAC-condensed Structures}
 \usage{
-parse_iupac_condensed(x, on_failure = "error", progress = FALSE)
+parse_iupac_condensed(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-condensed strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +18,10 @@ parse_iupac_condensed(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_extended.Rd
+++ b/man/parse_iupac_extended.Rd
@@ -4,7 +4,12 @@
 \alias{parse_iupac_extended}
 \title{Parse IUPAC-extended Structures}
 \usage{
-parse_iupac_extended(x, on_failure = "error", progress = FALSE)
+parse_iupac_extended(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-extended strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +18,10 @@ parse_iupac_extended(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_iupac_short.Rd
+++ b/man/parse_iupac_short.Rd
@@ -4,7 +4,12 @@
 \alias{parse_iupac_short}
 \title{Parse IUPAC-short Structures}
 \usage{
-parse_iupac_short(x, on_failure = "error", progress = FALSE)
+parse_iupac_short(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of IUPAC-short strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +18,10 @@ parse_iupac_short(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_kcf.Rd
+++ b/man/parse_kcf.Rd
@@ -4,7 +4,13 @@
 \alias{parse_kcf}
 \title{Parse KCF Structures}
 \usage{
-parse_kcf(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_kcf(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of KCF strings. NA values are allowed and will be returned as NA structures.}
@@ -16,6 +22,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_linear_code.Rd
+++ b/man/parse_linear_code.Rd
@@ -4,7 +4,12 @@
 \alias{parse_linear_code}
 \title{Parse Linear Code Structures}
 \usage{
-parse_linear_code(x, on_failure = "error", progress = FALSE)
+parse_linear_code(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of Linear Code strings. NA values are allowed and will be returned as NA structures.}
@@ -13,6 +18,10 @@ parse_linear_code(x, on_failure = "error", progress = FALSE)
 structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{progress}{Whether to show a progress bar while parsing.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_linucs.Rd
+++ b/man/parse_linucs.Rd
@@ -4,7 +4,13 @@
 \alias{parse_linucs}
 \title{Parse LINUCS Structures}
 \usage{
-parse_linucs(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_linucs(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of LINUCS strings. NA values are allowed and
@@ -17,6 +23,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.
@@ -31,7 +41,7 @@ linkage token, a residue token, and a braced child list, for example
 LINUCS linkages are written as \code{"(parent+child)"}, where \code{parent} is the
 linkage position on the parent residue and \code{child} is the anomeric linkage
 position on the child residue. Residue labels are normalized to the
-monosaccharide and substituent vocabulary used by \link[glyrepr:glyrepr]{glyrepr::glyrepr}.
+monosaccharide and substituent vocabulary used by \link[glyrepr:glyrepr-package]{glyrepr::glyrepr}.
 }
 \examples{
 linucs <- "[][b-D-Glcp]{[(4+1)][b-D-Galp]{}}"

--- a/man/parse_pglyco_struc.Rd
+++ b/man/parse_pglyco_struc.Rd
@@ -4,7 +4,13 @@
 \alias{parse_pglyco_struc}
 \title{Parse pGlyco Structures}
 \usage{
-parse_pglyco_struc(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_pglyco_struc(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of pGlyco-style structure strings. NA values are allowed and will be returned as NA structures.}
@@ -16,6 +22,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_strucgp_struc.Rd
+++ b/man/parse_strucgp_struc.Rd
@@ -4,7 +4,13 @@
 \alias{parse_strucgp_struc}
 \title{Parse StrucGP Structures}
 \usage{
-parse_strucgp_struc(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_strucgp_struc(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of StrucGP-style structure strings. NA values are allowed and will be returned as NA structures.}
@@ -16,6 +22,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -4,7 +4,13 @@
 \alias{parse_wurcs}
 \title{Parse WURCS Structures}
 \usage{
-parse_wurcs(x, on_failure = "error", progress = FALSE, validate = TRUE)
+parse_wurcs(
+  x,
+  on_failure = "error",
+  progress = FALSE,
+  validate = TRUE,
+  drop_generic = FALSE
+)
 }
 \arguments{
 \item{x}{A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.}
@@ -16,6 +22,10 @@ structure cannot be parsed. \code{"na"} returns \code{NA} at invalid positions.}
 
 \item{validate}{Whether to validate parsed glycan graphs before constructing
 the result.}
+
+\item{drop_generic}{Whether to replace parsed generic glycans with \code{NA}. A
+message reports the number replaced. By default, mixing generic and
+concrete glycans raises an error.}
 }
 \value{
 A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.

--- a/tests/testthat/_snaps/parse-iupac-condensed.md
+++ b/tests/testthat/_snaps/parse-iupac-condensed.md
@@ -7,3 +7,27 @@
       [1] Neu5Ac(a2-3)Gal(b1-4)[Fuc(a1-3)]GlcNAc(b1-6)[Neu5Ac(a2-3)Gal(b1-3)]GalNAc(b1-
       # Unique structures: 1
 
+# IUPAC-condensed can drop generic glycans
+
+    Code
+      parse_iupac_condensed(input)
+    Condition
+      Error in `validate_glycan_graph_vector()`:
+      ! All structures must have the same monosaccharide type.
+      x Found 1 concrete and 2 generic structure(s) in the same vector.
+      i Use `convert_to_generic()` to convert concrete structures to generic type.
+
+---
+
+    Code
+      result <- parse_iupac_condensed(input, drop_generic = TRUE)
+    Message
+      Dropped 2 generic glycans (replaced with `NA`).
+
+# drop_generic drops generic-only parser output
+
+    Code
+      result <- parse_pglyco_struc(c("(N)", "(H)"), drop_generic = TRUE)
+    Message
+      Dropped 2 generic glycans (replaced with `NA`).
+

--- a/tests/testthat/_snaps/struc-parser-wrapper.md
+++ b/tests/testthat/_snaps/struc-parser-wrapper.md
@@ -1,0 +1,16 @@
+# struc_parser_wrapper drops generic glycans by input position
+
+    Code
+      struc_parser_wrapper(input, do_parse_iupac_condensed)
+    Condition
+      Error in `glyrepr::validate_glycan_graph_vector()`:
+      ! All structures must have the same monosaccharide type.
+      x Found 1 concrete and 1 generic structure(s) in the same vector.
+      i Use `convert_to_generic()` to convert concrete structures to generic type.
+
+---
+
+    Code
+      result <- struc_parser_wrapper(input, do_parse_iupac_condensed, drop_generic = TRUE)
+    Message
+      Dropped 2 generic glycans (replaced with `NA`).

--- a/tests/testthat/test-parse-iupac-condensed.R
+++ b/tests/testthat/test-parse-iupac-condensed.R
@@ -4,3 +4,34 @@ test_that("IUPAC-condensed: some O-glycan", {
   glycan <- parse_iupac_condensed(to_parse)
   expect_snapshot(print(glycan, verbose = TRUE))
 })
+
+test_that("IUPAC-condensed can drop generic glycans", {
+  input <- c("Hex(??-", "Glc(?1-", "HexNAc(??-")
+
+  expect_snapshot(
+    error = TRUE,
+    parse_iupac_condensed(input)
+  )
+  expect_snapshot(
+    result <- parse_iupac_condensed(
+      input,
+      drop_generic = TRUE
+    )
+  )
+
+  expect_identical(
+    as.character(result),
+    c(NA_character_, "Glc(?1-", NA_character_)
+  )
+})
+
+test_that("drop_generic drops generic-only parser output", {
+  expect_snapshot(
+    result <- parse_pglyco_struc(
+      c("(N)", "(H)"),
+      drop_generic = TRUE
+    )
+  )
+
+  expect_identical(as.character(result), rep(NA_character_, 2))
+})

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -107,6 +107,28 @@ test_that("graph parsers expose validate", {
   }
 })
 
+test_that("all parsers expose drop_generic", {
+  parsers <- c(
+    "auto_parse",
+    "parse_glycam_iupac",
+    "parse_glycoct",
+    "parse_iupac_compact",
+    "parse_iupac_condensed",
+    "parse_iupac_extended",
+    "parse_iupac_short",
+    "parse_kcf",
+    "parse_linear_code",
+    "parse_linucs",
+    "parse_pglyco_struc",
+    "parse_strucgp_struc",
+    "parse_wurcs"
+  )
+
+  for (parser in parsers) {
+    expect_identical(formals(get(parser))$drop_generic, FALSE, info = parser)
+  }
+})
+
 test_that("struc_parser_wrapper avoids high-level structure constructors", {
   testthat::local_mocked_bindings(
     as_glycan_structure = function(...) {

--- a/tests/testthat/test-struc-parser-wrapper.R
+++ b/tests/testthat/test-struc-parser-wrapper.R
@@ -43,3 +43,30 @@ test_that("struc_parser_wrapper treats invalid parsed graphs as failures", {
 
   expect_identical(as.character(result), c("Hex(??-", NA_character_))
 })
+
+test_that("struc_parser_wrapper drops generic glycans by input position", {
+  input <- c(
+    generic = "Hex(??-",
+    concrete = "Glc(?1-",
+    generic_duplicate = "Hex(??-",
+    missing = NA_character_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    struc_parser_wrapper(input, do_parse_iupac_condensed)
+  )
+  expect_snapshot(
+    result <- struc_parser_wrapper(
+      input,
+      do_parse_iupac_condensed,
+      drop_generic = TRUE
+    )
+  )
+
+  expect_identical(
+    unname(as.character(result)),
+    c(NA_character_, "Glc(?1-", NA_character_, NA_character_)
+  )
+  expect_identical(names(result), names(input))
+})


### PR DESCRIPTION
## Summary

- Add `drop_generic = FALSE` to all exported parsers.
- Preserve the existing error when generic and concrete glycans coexist.
- With `drop_generic = TRUE`, replace generic glycans with `NA` and report the number dropped.
- Preserve input names, order, duplicates, and existing missing values.

## Verification

```r
parse_iupac_condensed(
  c("Hex(??-", "Glc(?1-", "HexNAc(??-"),
  drop_generic = TRUE
)
```

- `devtools::test()`: 1,099 passed
- `pkgdown::check_pkgdown()`: passed
- `devtools::check()`: 0 errors, 0 warnings