### PR TITLE
feat: parse floating GlycoCT and WURCS substructures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,10 @@
 * `parse_glycoct()` now supports floating glycan substructures represented by
   `UND` sections, uses implicit floating parts when every main-tree node is a
   candidate parent, and excludes explicit candidates whose acceptor positions
-  are already occupied.
+  are already occupied. (#40)
 * `parse_wurcs()` now supports floating monosaccharides and subtrees, including
   implicit all-main attachment domains and filtered explicit candidate
-  parents. It also recognizes furanose ring closures for pentose residues.
+  parents. It also recognizes furanose ring closures for pentose residues. (#40)
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
   `UND` sections, uses implicit floating parts when every main-tree node is a
   candidate parent, and excludes explicit candidates whose acceptor positions
   are already occupied.
+* `parse_wurcs()` now supports floating monosaccharides and subtrees, including
+  implicit all-main attachment domains and filtered explicit candidate
+  parents. It also recognizes furanose ring closures for pentose residues.
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
 # glyparse (development version)
 
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
+* `parse_glycoct()` now supports floating glycan substructures represented by
+  `UND` sections.
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).
 * `parse_glycoct()` and `parse_wurcs()` now reuse indexed residue matching and cached classification to improve parsing performance (#37).
-* `parse_glycoct()` now rejects unsupported GlycoCT `UND` sections through `on_failure` instead of silently returning an incomplete connected core (#38).
 
 # glyparse 0.7.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by
-  `UND` sections.
+  `UND` sections and excludes candidate parents whose acceptor positions are
+  already occupied.
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,8 @@
 # glyparse (development version)
 
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
-* `parse_glycoct()` now supports floating glycan substructures represented by
-  `UND` sections, uses implicit floating parts when every main-tree node is a
-  candidate parent, and excludes explicit candidates whose acceptor positions
-  are already occupied. (#40)
-* `parse_wurcs()` now supports floating monosaccharides and subtrees, including
-  implicit all-main attachment domains and filtered explicit candidate
-  parents. It also recognizes furanose ring closures for pentose residues. (#40)
+* `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)
+* `parse_wurcs()` now supports floating monosaccharides and subtrees, including implicit all-main attachment domains and filtered explicit candidate parents. It also recognizes supported `1-4` furanose rings, generic nonulosonic acids, and sialic acids with unknown ring closure. (#40)
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by
-  `UND` sections and excludes candidate parents whose acceptor positions are
-  already occupied.
+  `UND` sections, uses implicit floating parts when every main-tree node is a
+  candidate parent, and excludes explicit candidates whose acceptor positions
+  are already occupied.
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -569,7 +569,10 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
     seq_along(main$original_ids),
     main$original_ids
   )
-  occupied_slots <- glycoct_definitely_occupied_slots(main$graph)
+  occupied_slots <- definitely_occupied_acceptor_slots(
+    main$graph,
+    seq_along(main$original_ids)
+  )
   forest$floating_parts <- purrr::map2(
     seq_along(floating_graphs),
     floating,
@@ -593,11 +596,12 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
         metadata$child_pos,
         data$vertices[[root]]$anomer
       )
-      parents <- normalize_glycoct_und_parents(
+      parents <- normalize_floating_part_parents(
         parents,
         seq_along(main$original_ids),
         linkage,
-        occupied_slots
+        occupied_slots,
+        context = "GlycoCT UND part"
       )
 
       list(
@@ -612,21 +616,27 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
   forest
 }
 
-#' Find definitely occupied acceptor slots in a GlycoCT main tree
+#' Find definitely occupied acceptor slots in a glycan tree
 #'
-#' @param graph A parsed main-tree graph.
+#' @param graph A parsed glycan graph.
+#' @param vertices Vertices belonging to the tree of interest.
 #'
 #' @return Character keys combining parent vertex and acceptor position.
 #' @noRd
-glycoct_definitely_occupied_slots <- function(graph) {
+definitely_occupied_acceptor_slots <- function(
+  graph,
+  vertices = seq_len(igraph::vcount(graph))
+) {
   if (igraph::ecount(graph) == 0) {
     return(character())
   }
 
   endpoints <- igraph::as_edgelist(graph, names = FALSE)
   linkages <- igraph::edge_attr(graph, "linkage")
-  positions <- purrr::map(linkages, glycoct_acceptor_positions)
-  definite <- lengths(positions) == 1L
+  positions <- purrr::map(linkages, linkage_acceptor_positions)
+  definite <- lengths(positions) == 1L &
+    endpoints[, 1] %in% vertices &
+    endpoints[, 2] %in% vertices
 
   paste(
     endpoints[definite, 1],
@@ -641,7 +651,7 @@ glycoct_definitely_occupied_slots <- function(graph) {
 #'
 #' @return A character vector. Unknown positions return an empty vector.
 #' @noRd
-glycoct_acceptor_positions <- function(linkage) {
+linkage_acceptor_positions <- function(linkage) {
   acceptor <- stringr::str_extract(linkage, "(?<=-).*$")
   if (is.na(acceptor) || acceptor == "?") {
     return(character())
@@ -650,39 +660,52 @@ glycoct_acceptor_positions <- function(linkage) {
   stringr::str_split(acceptor, stringr::fixed("/"))[[1]]
 }
 
-#' Normalize GlycoCT UND candidate parents
+#' Normalize floating-part candidate parents
 #'
-#' @param parents Main-tree vertex indices declared by `ParentIDs`.
+#' @param parents Declared main-tree candidate vertex indices.
 #' @param main_vertices Every main-tree vertex index.
 #' @param linkage The floating part's attachment linkage.
 #' @param occupied_slots Definitely occupied main-tree acceptor slots.
+#' @param context Input-format context for error messages.
 #'
 #' @return An empty vector for an implicit all-main candidate set, otherwise
 #'   the feasible explicit candidate parents.
 #' @noRd
-normalize_glycoct_und_parents <- function(
+normalize_floating_part_parents <- function(
   parents,
   main_vertices,
   linkage,
-  occupied_slots
+  occupied_slots,
+  context
 ) {
   if (setequal(parents, main_vertices)) {
     return(integer())
   }
 
-  filter_glycoct_und_parents(parents, linkage, occupied_slots)
+  filter_floating_part_parents(
+    parents,
+    linkage,
+    occupied_slots,
+    context
+  )
 }
 
-#' Remove infeasible candidate parents from a GlycoCT UND part
+#' Remove infeasible candidate parents from a floating part
 #'
-#' @param parents Main-tree vertex indices declared by `ParentIDs`.
+#' @param parents Declared main-tree candidate vertex indices.
 #' @param linkage The floating part's attachment linkage.
 #' @param occupied_slots Definitely occupied main-tree acceptor slots.
+#' @param context Input-format context for error messages.
 #'
 #' @return Feasible candidate parent indices.
 #' @noRd
-filter_glycoct_und_parents <- function(parents, linkage, occupied_slots) {
-  positions <- glycoct_acceptor_positions(linkage)
+filter_floating_part_parents <- function(
+  parents,
+  linkage,
+  occupied_slots,
+  context
+) {
+  positions <- linkage_acceptor_positions(linkage)
   if (length(positions) == 0) {
     return(parents)
   }
@@ -694,11 +717,22 @@ filter_glycoct_und_parents <- function(parents, linkage, occupied_slots) {
   parents <- parents[feasible]
   if (length(parents) == 0) {
     cli::cli_abort(
-      "No feasible parent remains for a GlycoCT UND part after excluding occupied acceptor positions."
+      "No feasible parent remains for a {context} after excluding occupied acceptor positions.",
+      call = rlang::caller_env()
     )
   }
 
   parents
+}
+
+
+filter_glycoct_und_parents <- function(parents, linkage, occupied_slots) {
+  filter_floating_part_parents(
+    parents,
+    linkage,
+    occupied_slots,
+    context = "GlycoCT UND part"
+  )
 }
 
 #' Format the reducing-end anomer stored in a GlycoCT graph

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -70,7 +70,13 @@ do_parse_glycoct <- function(x) {
   blocks <- split_glycoct_blocks(lines)
 
   main <- parse_glycoct_block(blocks$main)
-  if (has_glycoct_alditol_residue(main$residues)) {
+  floating <- purrr::map(blocks$floating, parse_glycoct_und_block)
+  has_alditol <- has_glycoct_alditol_residue(main$residues) ||
+    any(purrr::map_lgl(
+      floating,
+      ~ has_glycoct_alditol_residue(.x$residues)
+    ))
+  if (has_alditol) {
     warn_glycoct_alditol()
   }
   main_graph <- build_glycoct_graph_data(main$residues, main$linkages)
@@ -79,7 +85,6 @@ do_parse_glycoct <- function(x) {
     return(main_graph$graph)
   }
 
-  floating <- purrr::map(blocks$floating, parse_glycoct_und_block)
   floating_graphs <- purrr::map(
     floating,
     ~ build_glycoct_graph_data(.x$residues, .x$linkages)

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -593,8 +593,9 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
         metadata$child_pos,
         data$vertices[[root]]$anomer
       )
-      parents <- filter_glycoct_und_parents(
+      parents <- normalize_glycoct_und_parents(
         parents,
+        seq_along(main$original_ids),
         linkage,
         occupied_slots
       )
@@ -647,6 +648,29 @@ glycoct_acceptor_positions <- function(linkage) {
   }
 
   stringr::str_split(acceptor, stringr::fixed("/"))[[1]]
+}
+
+#' Normalize GlycoCT UND candidate parents
+#'
+#' @param parents Main-tree vertex indices declared by `ParentIDs`.
+#' @param main_vertices Every main-tree vertex index.
+#' @param linkage The floating part's attachment linkage.
+#' @param occupied_slots Definitely occupied main-tree acceptor slots.
+#'
+#' @return An empty vector for an implicit all-main candidate set, otherwise
+#'   the feasible explicit candidate parents.
+#' @noRd
+normalize_glycoct_und_parents <- function(
+  parents,
+  main_vertices,
+  linkage,
+  occupied_slots
+) {
+  if (setequal(parents, main_vertices)) {
+    return(integer())
+  }
+
+  filter_glycoct_und_parents(parents, linkage, occupied_slots)
 }
 
 #' Remove infeasible candidate parents from a GlycoCT UND part

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -569,6 +569,7 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
     seq_along(main$original_ids),
     main$original_ids
   )
+  occupied_slots <- glycoct_definitely_occupied_slots(main$graph)
   forest$floating_parts <- purrr::map2(
     seq_along(floating_graphs),
     floating,
@@ -587,20 +588,93 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
         ))
       }
 
+      linkage <- format_glycoct_linkage(
+        metadata$parent_pos,
+        metadata$child_pos,
+        data$vertices[[root]]$anomer
+      )
+      parents <- filter_glycoct_und_parents(
+        parents,
+        linkage,
+        occupied_slots
+      )
+
       list(
         root = as.integer(offset + root),
         nodes = as.integer(offset + seq_len(sizes[[part_id + 1L]])),
-        linkage = format_glycoct_linkage(
-          metadata$parent_pos,
-          metadata$child_pos,
-          data$vertices[[root]]$anomer
-        ),
+        linkage = linkage,
         parents = as.integer(parents)
       )
     }
   )
 
   forest
+}
+
+#' Find definitely occupied acceptor slots in a GlycoCT main tree
+#'
+#' @param graph A parsed main-tree graph.
+#'
+#' @return Character keys combining parent vertex and acceptor position.
+#' @noRd
+glycoct_definitely_occupied_slots <- function(graph) {
+  if (igraph::ecount(graph) == 0) {
+    return(character())
+  }
+
+  endpoints <- igraph::as_edgelist(graph, names = FALSE)
+  linkages <- igraph::edge_attr(graph, "linkage")
+  positions <- purrr::map(linkages, glycoct_acceptor_positions)
+  definite <- lengths(positions) == 1L
+
+  paste(
+    endpoints[definite, 1],
+    unlist(positions[definite], use.names = FALSE),
+    sep = "\r"
+  )
+}
+
+#' Extract possible acceptor positions from an IUPAC linkage
+#'
+#' @param linkage An IUPAC-condensed linkage.
+#'
+#' @return A character vector. Unknown positions return an empty vector.
+#' @noRd
+glycoct_acceptor_positions <- function(linkage) {
+  acceptor <- stringr::str_extract(linkage, "(?<=-).*$")
+  if (is.na(acceptor) || acceptor == "?") {
+    return(character())
+  }
+
+  stringr::str_split(acceptor, stringr::fixed("/"))[[1]]
+}
+
+#' Remove infeasible candidate parents from a GlycoCT UND part
+#'
+#' @param parents Main-tree vertex indices declared by `ParentIDs`.
+#' @param linkage The floating part's attachment linkage.
+#' @param occupied_slots Definitely occupied main-tree acceptor slots.
+#'
+#' @return Feasible candidate parent indices.
+#' @noRd
+filter_glycoct_und_parents <- function(parents, linkage, occupied_slots) {
+  positions <- glycoct_acceptor_positions(linkage)
+  if (length(positions) == 0) {
+    return(parents)
+  }
+
+  feasible <- purrr::map_lgl(parents, function(parent) {
+    slots <- paste(parent, positions, sep = "\r")
+    any(!slots %in% occupied_slots)
+  })
+  parents <- parents[feasible]
+  if (length(parents) == 0) {
+    cli::cli_abort(
+      "No feasible parent remains for a GlycoCT UND part after excluding occupied acceptor positions."
+    )
+  }
+
+  parents
 }
 
 #' Format the reducing-end anomer stored in a GlycoCT graph

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -189,6 +189,11 @@ parse_glycoct_und_block <- function(lines) {
       "Can't parse GlycoCT UND subtree linkage {.val {attachment}}"
     )
   }
+  if (stringr::str_detect(matches[3], stringr::fixed("|"))) {
+    cli::cli_abort(
+      "GlycoCT UND linkages with alternative donor positions are not supported: {.val {attachment}}"
+    )
+  }
 
   block <- parse_glycoct_block(lines)
   c(

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -4,16 +4,14 @@
 #' GlycoCT is a format used by databases like GlyTouCan and GlyGen.
 #'
 #' @details
-#' GlycoCT format consists of two parts:
+#' GlycoCT format consists of:
 #' - RES: Contains monosaccharides (lines starting with 'b:') and substituents (lines starting with 's:')
 #' - LIN: Contains linkage information between residues
+#' - UND: Contains floating substructures whose attachment to the main glycan
+#'   is unresolved
 #'
 #' Alditol residues are parsed as regular reducing-end glycans with unknown
 #' anomer configurations.
-#'
-#' GlycoCT `UND` sections are not currently supported. Inputs containing an
-#' underdetermined subgraph fail according to `on_failure` instead of returning
-#' an incomplete connected core.
 #'
 #' For more information about GlycoCT format, see the glycoct.md documentation.
 #'
@@ -57,18 +55,6 @@ parse_glycoct <- function(
     drop_generic,
     call = rlang::caller_env()
   )
-  has_und <- purrr::map_lgl(
-    x,
-    \(value) !is.na(value) && has_glycoct_und_section(value)
-  )
-  if (any(has_und) && on_failure == "error") {
-    cli::cli_abort(c(
-      "Can't parse GlycoCT with unsupported {.code UND} sections.",
-      "i" = "Returning only the connected {.code RES}/{.code LIN} core would lose underdetermined residues."
-    ))
-  }
-  x[has_und] <- NA_character_
-
   struc_parser_wrapper(
     x,
     do_parse_glycoct,
@@ -79,55 +65,140 @@ parse_glycoct <- function(
   )
 }
 
-#' Detect underdetermined GlycoCT subgraphs
-#'
-#' @param x A non-missing GlycoCT string.
-#'
-#' @return A logical scalar.
-#' @noRd
-has_glycoct_und_section <- function(x) {
-  any(stringr::str_detect(split_glycoct_lines(x), "^UND(?:\\d+)?$"))
-}
-
 do_parse_glycoct <- function(x) {
   lines <- split_glycoct_lines(x)
-  if (any(stringr::str_detect(lines, "^UND(?:\\d+)?$"))) {
-    cli::cli_abort("GlycoCT {.code UND} sections are not supported")
+  blocks <- split_glycoct_blocks(lines)
+
+  main <- parse_glycoct_block(blocks$main)
+  if (has_glycoct_alditol_residue(main$residues)) {
+    warn_glycoct_alditol()
+  }
+  main_graph <- build_glycoct_graph_data(main$residues, main$linkages)
+
+  if (length(blocks$floating) == 0) {
+    return(main_graph$graph)
   }
 
-  # Find RES and LIN sections
+  floating <- purrr::map(blocks$floating, parse_glycoct_und_block)
+  floating_graphs <- purrr::map(
+    floating,
+    ~ build_glycoct_graph_data(.x$residues, .x$linkages)
+  )
+
+  build_glycoct_floating_graph(main_graph, floating_graphs, floating)
+}
+
+#' Split a GlycoCT record into its main and UND blocks
+#'
+#' @param lines Tokenized GlycoCT lines.
+#'
+#' @return A list containing the main block and zero or more floating blocks.
+#' @noRd
+split_glycoct_blocks <- function(lines) {
+  und_marker <- which(lines == "UND")
+  if (length(und_marker) == 0) {
+    return(list(main = lines, floating = list()))
+  }
+
+  first_und <- und_marker[[1]]
+  main <- lines[seq_len(first_und - 1L)]
+  und_lines <- lines[(first_und + 1L):length(lines)]
+  starts <- which(stringr::str_detect(und_lines, "^UND\\d+:"))
+  if (length(starts) == 0) {
+    cli::cli_abort("No UND block found after the GlycoCT UND section")
+  }
+
+  ends <- c(starts[-1] - 1L, length(und_lines))
+  floating <- purrr::map2(
+    starts,
+    ends,
+    ~ und_lines[.x:.y]
+  )
+
+  list(main = main, floating = floating)
+}
+
+#' Parse the structural sections of one GlycoCT block
+#'
+#' @param lines Lines containing one RES section and an optional LIN section.
+#'
+#' @return Parsed residues and linkages.
+#' @noRd
+parse_glycoct_block <- function(lines) {
   res_start <- which(lines == "RES")
   lin_start <- which(lines == "LIN")
 
-  if (length(res_start) == 0) {
-    cli::cli_abort("No RES section found in GlycoCT string")
+  if (length(res_start) != 1) {
+    cli::cli_abort("A GlycoCT block must contain exactly one RES section")
+  }
+  if (length(lin_start) > 1) {
+    cli::cli_abort("A GlycoCT block can contain at most one LIN section")
   }
 
-  # Parse RES section
-  if (length(lin_start) == 0) {
-    res_lines <- lines[(res_start + 1):length(lines)]
+  res_end <- if (length(lin_start) == 0) {
+    length(lines)
   } else {
-    res_lines <- lines[(res_start + 1):(lin_start - 1)]
+    lin_start - 1L
   }
-
-  # Parse LIN section (if exists)
-  if (length(lin_start) > 0) {
-    lin_lines <- lines[(lin_start + 1):length(lines)]
+  res_lines <- lines[(res_start + 1L):res_end]
+  lin_lines <- if (length(lin_start) == 0) {
+    character()
   } else {
-    lin_lines <- character(0)
+    lines[(lin_start + 1L):length(lines)]
   }
 
-  # Parse residues (monosaccharides and substituents)
-  residues <- parse_res_section(res_lines)
-  if (has_glycoct_alditol_residue(residues)) {
-    warn_glycoct_alditol()
+  list(
+    residues = parse_res_section(res_lines),
+    linkages = parse_lin_section(lin_lines)
+  )
+}
+
+#' Parse a GlycoCT UND block
+#'
+#' @param lines One UND block, beginning with its UND identifier.
+#'
+#' @return Parsed structural data and virtual attachment metadata.
+#' @noRd
+parse_glycoct_und_block <- function(lines) {
+  parent_line <- lines[stringr::str_detect(lines, "^ParentIDs:")]
+  linkage_line <- lines[
+    stringr::str_detect(lines, "^SubtreeLinkageID\\d+:")
+  ]
+  if (length(parent_line) != 1 || length(linkage_line) != 1) {
+    cli::cli_abort(
+      "A GlycoCT UND block must contain one ParentIDs and one SubtreeLinkageID field"
+    )
   }
 
-  # Parse linkages
-  linkages <- parse_lin_section(lin_lines)
+  parent_text <- stringr::str_remove(parent_line, "^ParentIDs:")
+  parent_ids <- as.integer(stringr::str_split(parent_text, "\\|")[[1]])
+  if (length(parent_ids) == 0 || anyNA(parent_ids)) {
+    cli::cli_abort("GlycoCT UND ParentIDs must contain residue identifiers")
+  }
 
-  # Build the graph
-  build_glycoct_graph(residues, linkages)
+  attachment <- stringr::str_remove(
+    linkage_line,
+    "^SubtreeLinkageID\\d+:"
+  )
+  matches <- stringr::str_match(
+    attachment,
+    "^[a-z]?\\((-?\\d+(?:\\|\\d+)*)\\+(-?\\d+(?:\\|\\d+)*)\\)[a-z]?$"
+  )
+  if (is.na(matches[1])) {
+    cli::cli_abort(
+      "Can't parse GlycoCT UND subtree linkage {.val {attachment}}"
+    )
+  }
+
+  block <- parse_glycoct_block(lines)
+  c(
+    block,
+    list(
+      parent_ids = parent_ids,
+      parent_pos = matches[2],
+      child_pos = matches[3]
+    )
+  )
 }
 
 #' Split a GlycoCT record into parser lines
@@ -311,7 +382,7 @@ parse_lin_section <- function(lin_lines) {
       to_res <- as.integer(matches[6])
       to_pos <- matches[5]
 
-      linkages[[link_id]] <- list(
+      linkages[[as.character(link_id)]] <- list(
         from_res = from_res,
         from_pos = from_pos,
         to_res = to_res,
@@ -324,6 +395,10 @@ parse_lin_section <- function(lin_lines) {
 }
 
 build_glycoct_graph <- function(residues, linkages) {
+  build_glycoct_graph_data(residues, linkages)$graph
+}
+
+build_glycoct_graph_data <- function(residues, linkages) {
   mono_mapping_index <- glycoct_mapping_index()
 
   # Consolidate monosaccharides with their substituents
@@ -356,31 +431,15 @@ build_glycoct_graph <- function(residues, linkages) {
     if (length(from_idx) == 1 && length(to_idx) == 1) {
       edges <- c(edges, from_idx, to_idx)
 
-      # Build linkage string: anomer + to_pos + "-" + from_pos
       to_vertex <- consolidated$vertices[[to_idx]]
-
-      # Handle unknown anomer and positions
-      anomer_char <- if (to_vertex$anomer %in% c("x", "o")) {
-        "?"
-      } else {
-        to_vertex$anomer
-      }
-      to_pos_str <- if (edge$to_pos == "-1") "?" else as.character(edge$to_pos)
-      from_pos_str <- if (edge$from_pos == "-1") {
-        "?"
-      } else {
-        as.character(edge$from_pos)
-      }
-      if (stringr::str_detect(from_pos_str, stringr::fixed("|"))) {
-        from_pos_str <- stringr::str_replace_all(
-          from_pos_str,
-          stringr::fixed("|"),
-          stringr::fixed("/")
+      edge_attrs$linkage <- c(
+        edge_attrs$linkage,
+        format_glycoct_linkage(
+          edge$from_pos,
+          edge$to_pos,
+          to_vertex$anomer
         )
-      }
-
-      linkage_str <- paste0(anomer_char, to_pos_str, "-", from_pos_str)
-      edge_attrs$linkage <- c(edge_attrs$linkage, linkage_str)
+      )
     }
   }
 
@@ -416,7 +475,132 @@ build_glycoct_graph <- function(residues, linkages) {
   }
   g$alditol <- FALSE
 
-  g
+  list(
+    graph = g,
+    original_ids = purrr::map_int(
+      consolidated$vertices,
+      "original_id"
+    ),
+    vertices = consolidated$vertices
+  )
+}
+
+#' Format a GlycoCT linkage as IUPAC-condensed linkage text
+#'
+#' @param parent_pos Acceptor position on the parent residue.
+#' @param child_pos Donor position on the child residue.
+#' @param child_anomer Anomer configuration of the child residue.
+#'
+#' @return A linkage string such as `"a2-3"` or `"?1-?"`.
+#' @noRd
+format_glycoct_linkage <- function(parent_pos, child_pos, child_anomer) {
+  anomer <- if (child_anomer %in% c("x", "o")) "?" else child_anomer
+  donor <- if (child_pos == "-1") "?" else child_pos
+  acceptor <- if (parent_pos == "-1") "?" else parent_pos
+  acceptor <- stringr::str_replace_all(
+    acceptor,
+    stringr::fixed("|"),
+    stringr::fixed("/")
+  )
+
+  paste0(anomer, donor, "-", acceptor)
+}
+
+#' Combine a main GlycoCT tree with parsed UND subtree graphs
+#'
+#' @param main Main-tree graph data.
+#' @param floating_graphs Graph data for each floating subtree.
+#' @param floating Parsed UND metadata.
+#'
+#' @return An annotated glycan forest understood by `glyrepr`.
+#' @noRd
+build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
+  graph_data <- c(list(main), floating_graphs)
+  sizes <- purrr::map_int(graph_data, ~ igraph::vcount(.x$graph))
+  offsets <- c(0L, utils::head(cumsum(sizes), -1L))
+
+  forest <- igraph::make_empty_graph(sum(sizes), directed = TRUE)
+  edge_endpoints <- purrr::map2(
+    graph_data,
+    offsets,
+    function(data, offset) {
+      endpoints <- igraph::as_edgelist(data$graph, names = FALSE)
+      if (length(endpoints) == 0) {
+        return(integer())
+      }
+      as.integer(t(endpoints + offset))
+    }
+  )
+  edge_endpoints <- unlist(edge_endpoints, use.names = FALSE)
+  edge_linkages <- unlist(
+    purrr::map(
+      graph_data,
+      ~ igraph::edge_attr(.x$graph, "linkage")
+    ),
+    use.names = FALSE
+  )
+  if (length(edge_endpoints) > 0) {
+    forest <- igraph::add_edges(
+      forest,
+      edge_endpoints,
+      linkage = edge_linkages
+    )
+  } else {
+    forest <- igraph::set_edge_attr(
+      forest,
+      "linkage",
+      value = character()
+    )
+  }
+
+  igraph::V(forest)$name <- as.character(seq_len(sum(sizes)))
+  igraph::V(forest)$mono <- unlist(
+    purrr::map(graph_data, ~ igraph::V(.x$graph)$mono),
+    use.names = FALSE
+  )
+  igraph::V(forest)$sub <- unlist(
+    purrr::map(graph_data, ~ igraph::V(.x$graph)$sub),
+    use.names = FALSE
+  )
+  forest$anomer <- main$graph$anomer
+  forest$alditol <- FALSE
+
+  main_parent_indices <- stats::setNames(
+    seq_along(main$original_ids),
+    main$original_ids
+  )
+  forest$floating_parts <- purrr::map2(
+    seq_along(floating_graphs),
+    floating,
+    function(part_id, metadata) {
+      data <- floating_graphs[[part_id]]
+      offset <- offsets[[part_id + 1L]]
+      root <- which(igraph::degree(data$graph, mode = "in") == 0)
+      parents <- unname(
+        main_parent_indices[as.character(metadata$parent_ids)]
+      )
+      if (anyNA(parents)) {
+        missing_ids <- metadata$parent_ids[is.na(parents)]
+        cli::cli_abort(c(
+          "GlycoCT UND candidate parents must be main-tree monosaccharides.",
+          "x" = "Can't find main-tree residue ID{?s} {.val {missing_ids}}."
+        ))
+      }
+
+      list(
+        root = as.integer(offset + root),
+        nodes = as.integer(offset + seq_len(sizes[[part_id + 1L]])),
+        linkage = format_glycoct_linkage(
+          metadata$parent_pos,
+          metadata$child_pos,
+          data$vertices[[root]]$anomer
+        ),
+        parents = as.integer(parents)
+      )
+    }
+  )
+
+  forest
 }
 
 #' Format the reducing-end anomer stored in a GlycoCT graph

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -137,6 +137,12 @@ WURCS_MONO_REGEX <- c(
   "Xyl" = "^a212h-1[abx]_1-[45]",
   "Rib" = "^a222h-1[abx]_1-[45]",
 
+  # Generic nonulosonic acids with unknown stereochemistry.
+  "NeuAc" = "^Aadxxxxxh-2[abx]_2-6_5\\*NCC/3=O",
+  "NeuGc" = "^Aadxxxxxh-2[abx]_2-6_5\\*NCCO/3=O",
+  "gNeu" = "^Aadxxxxxh-2[abx]_2-6_5\\*N(?!CC(O)?/3=O)",
+  "gKdn" = "^Aadxxxxxh-2[abx]_2-6(?!_5\\*N)",
+
   # Neu5Ac and Neu5Gc - match if contains _5*NCC/3=O or _5*NCCO/3=O anywhere in the string
   # These must come before Kdn since they are more specific
   "Neu5Ac" = "^Aad21122h-2[abx]_2-6.*_5\\*NCC/3=O",
@@ -178,6 +184,11 @@ WURCS_MONO_REGEX <- c(
 
 
 WURCS_UNKNOWN_RING_MONO_REGEX <- c(
+  "NeuAc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCC/3=O",
+  "NeuGc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCCO/3=O",
+  "gNeu" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
+  "gKdn" = "^Aadxxxxxh-2[abx]_2-\\?(?!_5\\*N)",
+
   "GlcNAc" = "^a2122h-1[abx]_1-\\?_2\\*NCC/3=O",
   "GalNAc" = "^a2112h-1[abx]_1-\\?_2\\*NCC/3=O",
   "ManNAc" = "^a1122h-1[abx]_1-\\?_2\\*NCC/3=O",
@@ -251,6 +262,11 @@ WURCS_UNKNOWN_RING_MONO_REGEX <- c(
 
 
 WURCS_AMBIGUOUS_MONO_REGEX <- c(
+  "NeuAc" = "^AUdxxxxxh_5\\*NCC/3=O",
+  "NeuGc" = "^AUdxxxxxh_5\\*NCCO/3=O",
+  "gNeu" = "^AUdxxxxxh_5\\*N(?!CC(O)?/3=O)",
+  "gKdn" = "^AUdxxxxxh(?!_5\\*N)",
+
   "Neu5Ac" = "^AUd21122h.*_5\\*NCC/3=O",
   "Neu5Gc" = "^AUd21122h.*_5\\*NCCO/3=O",
   "Neu" = "^AUd21122h.*_5\\*N",
@@ -382,6 +398,11 @@ WURCS_ALDITOL_MONO_REGEX <- c(
   "Lyx" = "^h221h",
   "Xyl" = "^h212h",
   "Rib" = "^h222h",
+
+  "NeuAc" = "^hUdxxxxxh_5\\*NCC/3=O",
+  "NeuGc" = "^hUdxxxxxh_5\\*NCCO/3=O",
+  "gNeu" = "^hUdxxxxxh_5\\*N(?!CC(O)?/3=O)",
+  "gKdn" = "^hUdxxxxxh(?!_5\\*N)",
 
   "Neu5Ac" = "^hUd21122h_5\\*NCC/3=O",
   "Neu5Gc" = "^hUd21122h_5\\*NCCO/3=O",

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -149,10 +149,10 @@ WURCS_MONO_REGEX <- c(
   "Neu5Gc" = "^Aad21122h-2[abx]_2-6.*_5\\*NCCO/3=O",
 
   # Kdn: exclude N, Ac, and Gc
-  "Kdn" = "^Aad21122h-2[abx]_2-6(?!_5\\*N(CC(O)?/3=O)?)",
+  "Kdn" = "^Aad21122h-2[abx]_2-6(?!.*_5\\*N(CC(O)?/3=O)?)",
 
   # Neu: exclude Ac and Gc
-  "Neu" = "^Aad21122h-2[abx]_2-6_5\\*N(?!CC(O)?/3=O)",
+  "Neu" = "^Aad21122h-2[abx]_2-6(?=.*_5\\*N(?!CC(O)?/3=O))",
 
   # Rest of the monosaccharides are themselves.
   "Pse" = "^had22111m-2[abx]_2-6_5\\*N_7\\*N",
@@ -184,10 +184,10 @@ WURCS_MONO_REGEX <- c(
 
 
 WURCS_UNKNOWN_RING_MONO_REGEX <- c(
-  "Neu5Ac" = "^Aad21122h-2[abx]_2-\\?_5\\*NCC/3=O",
-  "Neu5Gc" = "^Aad21122h-2[abx]_2-\\?_5\\*NCCO/3=O",
-  "Neu" = "^Aad21122h-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
-  "Kdn" = "^Aad21122h-2[abx]_2-\\?(?!_5\\*N)",
+  "Neu5Ac" = "^Aad21122h-2[abx]_2-\\?(?=.*_5\\*NCC/3=O)",
+  "Neu5Gc" = "^Aad21122h-2[abx]_2-\\?(?=.*_5\\*NCCO/3=O)",
+  "Neu" = "^Aad21122h-2[abx]_2-\\?(?=.*_5\\*N(?!CC(O)?/3=O))",
+  "Kdn" = "^Aad21122h-2[abx]_2-\\?(?!.*_5\\*N)",
   "NeuAc" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*NCC/3=O)",
   "NeuGc" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*NCCO/3=O)",
   "gNeu" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*N(?!CC(O)?/3=O))",
@@ -647,7 +647,7 @@ parse_residue_details <- function(residue) {
   # is part of the monosaccharide itself, not an additional substituent
   if (
     mono %in%
-      c("Neu5Ac", "Neu5Gc") &&
+      c("Neu5Ac", "Neu5Gc", "Neu") &&
       !is_alditol &&
       stringr::str_starts(residue, "Aad")
   ) {
@@ -657,11 +657,16 @@ parse_residue_details <- function(residue) {
       # Remove the base Kdn pattern and the 5*NCC/3=O
       sub_code <- stringr::str_remove(residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
-    } else {
-      # Neu5Gc
+    } else if (mono == "Neu5Gc") {
       # Remove the base Kdn pattern and the 5*NCCO/3=O
       sub_code <- stringr::str_remove(residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
+    } else {
+      sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+      sub_code <- stringr::str_remove(
+        sub_code,
+        "_5\\*N(?!CC(O)?/3=O)"
+      )
     }
   } else if (
     mono %in%

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -573,16 +573,21 @@ parse_residue_details <- function(residue) {
   #        for multiple substituents, they are separated by commas, e.g. "3Me,6S"
 
   is_alditol <- FALSE
+  matching_residue <- stringr::str_replace(
+    residue,
+    "(-1[abx]_1)-4",
+    "\\1-5"
+  )
 
   # Get monosaacharide name
   mono_idx <- detect_wurcs_pattern(
-    residue,
+    matching_residue,
     WURCS_MONO_REGEX,
     WURCS_MONO_PREFIXES
   )
   if (mono_idx == 0) {
     unknown_ring_mono_idx <- detect_wurcs_pattern(
-      residue,
+      matching_residue,
       WURCS_UNKNOWN_RING_MONO_REGEX,
       WURCS_UNKNOWN_RING_MONO_PREFIXES
     )
@@ -597,7 +602,7 @@ parse_residue_details <- function(residue) {
       )
     } else {
       alditol_mono_idx <- detect_wurcs_pattern(
-        residue,
+        matching_residue,
         WURCS_ALDITOL_MONO_REGEX,
         WURCS_ALDITOL_MONO_PREFIXES
       )
@@ -608,7 +613,7 @@ parse_residue_details <- function(residue) {
         is_alditol <- TRUE
       } else {
         ambiguous_mono_idx <- detect_wurcs_pattern(
-          residue,
+          matching_residue,
           WURCS_AMBIGUOUS_MONO_REGEX,
           WURCS_AMBIGUOUS_MONO_PREFIXES
         )
@@ -670,7 +675,7 @@ parse_residue_details <- function(residue) {
     }
   } else {
     # For other monosaccharides, use the standard approach
-    sub_code <- stringr::str_remove(residue, mono_pattern)
+    sub_code <- stringr::str_remove(matching_residue, mono_pattern)
   }
   sub_code <- normalize_n_sulfate_sub_code(residue, sub_code)
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -846,11 +846,11 @@ parse_wurcs_floating_linkage <- function(x) {
     purrr::map_chr(candidates, "position"),
     candidate_nodes
   )
-  position_sets <- unique(purrr::map_chr(
+  position_sets <- purrr::map(
     positions_by_parent,
-    ~ paste(unique(.x), collapse = "/")
-  ))
-  if (length(position_sets) != 1L) {
+    ~ sort(unique(.x))
+  )
+  if (length(unique(position_sets)) != 1L) {
     cli::cli_abort(
       "Floating WURCS linkages with parent-specific acceptor positions are not supported: {.str {x}}"
     )
@@ -859,7 +859,7 @@ parse_wurcs_floating_linkage <- function(x) {
   list(
     root = child$node,
     child_position = child$position,
-    parent_positions = unique(purrr::map_chr(candidates, "position")),
+    parent_positions = position_sets[[1]],
     parents = unique(candidate_nodes)
   )
 }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -847,12 +847,22 @@ parse_one_linkage <- function(x, anomers = NULL) {
   # Input: a string of one WURCS linkage, e.g. "a4-b1"
   # Output: a named list of `from`, `to`, and `linkage`
   spl <- stringr::str_split_1(x, "-")
-  if (!is.null(anomers)) {
+  if (is.null(anomers)) {
+    swap_endpoints <- stringr::str_detect(
+      spl[[2]],
+      stringr::fixed("|")
+    )
+  } else {
     left_donor <- wurcs_endpoint_can_be_donor(spl[[1]], anomers)
     right_donor <- wurcs_endpoint_can_be_donor(spl[[2]], anomers)
-    if (left_donor && !right_donor) {
-      spl <- rev(spl)
-    }
+    swap_endpoints <- left_donor &&
+      !right_donor ||
+      !left_donor &&
+        !right_donor &&
+        stringr::str_detect(spl[[2]], stringr::fixed("|"))
+  }
+  if (swap_endpoints) {
+    spl <- rev(spl)
   }
 
   handle_parallel_pos <- function(part) {
@@ -869,21 +879,6 @@ parse_one_linkage <- function(x, anomers = NULL) {
 
   from_part <- handle_parallel_pos(spl[[1]])
   to_part <- handle_parallel_pos(spl[[2]])
-  if (
-    is.null(anomers) &&
-      stringr::str_detect(to_part, stringr::fixed("/"))
-  ) {
-    # WURCS has a strange linkage rule:
-    # In the normal case, the linkage positions are opposite to the orders of IUPAC.
-    # For example, "a4-b1" means "1-4" in IUPAC.
-    # However, when second position is a parallel position, e.g. "b2|b2",
-    # the linkage positions are the same as the orders of IUPAC.
-    # For example, "f2-g3|g6" means "2-3/6" in IUPAC.
-    # In this case, we need to swap from_part and to_part.
-    temp <- from_part
-    from_part <- to_part
-    to_part <- temp
-  }
 
   from_idx <- letter_to_int(stringr::str_sub(from_part, 1, 1))
   to_idx <- letter_to_int(stringr::str_sub(to_part, 1, 1))
@@ -925,7 +920,7 @@ prepare_graph_dfs <- function(residues, linkages) {
     residues,
     ~ data.frame(as.list(.x))
   ))
-  if (is.null(linkages)) {
+  if (length(linkages) == 0L) {
     edgelist_df <- data.frame(
       from = integer(),
       to = integer(),

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -138,10 +138,10 @@ WURCS_MONO_REGEX <- c(
   "Rib" = "^a222h-1[abx]_1-[45]",
 
   # Generic nonulosonic acids with unknown stereochemistry.
-  "NeuAc" = "^Aadxxxxxh-2[abx]_2-6_5\\*NCC/3=O",
-  "NeuGc" = "^Aadxxxxxh-2[abx]_2-6_5\\*NCCO/3=O",
-  "gNeu" = "^Aadxxxxxh-2[abx]_2-6_5\\*N(?!CC(O)?/3=O)",
-  "gKdn" = "^Aadxxxxxh-2[abx]_2-6(?!_5\\*N)",
+  "NeuAc" = "^Aadxxxxxh-2[abx]_2-6(?=.*_5\\*NCC/3=O)",
+  "NeuGc" = "^Aadxxxxxh-2[abx]_2-6(?=.*_5\\*NCCO/3=O)",
+  "gNeu" = "^Aadxxxxxh-2[abx]_2-6(?=.*_5\\*N(?!CC(O)?/3=O))",
+  "gKdn" = "^Aadxxxxxh-2[abx]_2-6(?!.*_5\\*N)",
 
   # Neu5Ac and Neu5Gc - match if contains _5*NCC/3=O or _5*NCCO/3=O anywhere in the string
   # These must come before Kdn since they are more specific
@@ -188,10 +188,10 @@ WURCS_UNKNOWN_RING_MONO_REGEX <- c(
   "Neu5Gc" = "^Aad21122h-2[abx]_2-\\?_5\\*NCCO/3=O",
   "Neu" = "^Aad21122h-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
   "Kdn" = "^Aad21122h-2[abx]_2-\\?(?!_5\\*N)",
-  "NeuAc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCC/3=O",
-  "NeuGc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCCO/3=O",
-  "gNeu" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
-  "gKdn" = "^Aadxxxxxh-2[abx]_2-\\?(?!_5\\*N)",
+  "NeuAc" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*NCC/3=O)",
+  "NeuGc" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*NCCO/3=O)",
+  "gNeu" = "^Aadxxxxxh-2[abx]_2-\\?(?=.*_5\\*N(?!CC(O)?/3=O))",
+  "gKdn" = "^Aadxxxxxh-2[abx]_2-\\?(?!.*_5\\*N)",
 
   "GlcNAc" = "^a2122h-1[abx]_1-\\?_2\\*NCC/3=O",
   "GalNAc" = "^a2112h-1[abx]_1-\\?_2\\*NCC/3=O",
@@ -266,10 +266,10 @@ WURCS_UNKNOWN_RING_MONO_REGEX <- c(
 
 
 WURCS_AMBIGUOUS_MONO_REGEX <- c(
-  "NeuAc" = "^AUdxxxxxh_5\\*NCC/3=O",
-  "NeuGc" = "^AUdxxxxxh_5\\*NCCO/3=O",
-  "gNeu" = "^AUdxxxxxh_5\\*N(?!CC(O)?/3=O)",
-  "gKdn" = "^AUdxxxxxh(?!_5\\*N)",
+  "NeuAc" = "^AUdxxxxxh(?=.*_5\\*NCC/3=O)",
+  "NeuGc" = "^AUdxxxxxh(?=.*_5\\*NCCO/3=O)",
+  "gNeu" = "^AUdxxxxxh(?=.*_5\\*N(?!CC(O)?/3=O))",
+  "gKdn" = "^AUdxxxxxh(?!.*_5\\*N)",
 
   "Neu5Ac" = "^AUd21122h.*_5\\*NCC/3=O",
   "Neu5Gc" = "^AUd21122h.*_5\\*NCCO/3=O",
@@ -403,10 +403,10 @@ WURCS_ALDITOL_MONO_REGEX <- c(
   "Xyl" = "^h212h",
   "Rib" = "^h222h",
 
-  "NeuAc" = "^hUdxxxxxh_5\\*NCC/3=O",
-  "NeuGc" = "^hUdxxxxxh_5\\*NCCO/3=O",
-  "gNeu" = "^hUdxxxxxh_5\\*N(?!CC(O)?/3=O)",
-  "gKdn" = "^hUdxxxxxh(?!_5\\*N)",
+  "NeuAc" = "^hUdxxxxxh(?=.*_5\\*NCC/3=O)",
+  "NeuGc" = "^hUdxxxxxh(?=.*_5\\*NCCO/3=O)",
+  "gNeu" = "^hUdxxxxxh(?=.*_5\\*N(?!CC(O)?/3=O))",
+  "gKdn" = "^hUdxxxxxh(?!.*_5\\*N)",
 
   "Neu5Ac" = "^hUd21122h_5\\*NCC/3=O",
   "Neu5Gc" = "^hUd21122h_5\\*NCCO/3=O",
@@ -673,6 +673,15 @@ parse_residue_details <- function(residue) {
     if (mono == "Neu5Ac") {
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
     } else if (mono == "Neu5Gc") {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
+    } else {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*N(?!CC(O)?/3=O)")
+    }
+  } else if (mono %in% c("NeuAc", "NeuGc", "gNeu")) {
+    sub_code <- stringr::str_remove(matching_residue, mono_pattern)
+    if (mono == "NeuAc") {
+      sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
+    } else if (mono == "NeuGc") {
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
     } else {
       sub_code <- stringr::str_remove(sub_code, "_5\\*N(?!CC(O)?/3=O)")

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -184,6 +184,10 @@ WURCS_MONO_REGEX <- c(
 
 
 WURCS_UNKNOWN_RING_MONO_REGEX <- c(
+  "Neu5Ac" = "^Aad21122h-2[abx]_2-\\?_5\\*NCC/3=O",
+  "Neu5Gc" = "^Aad21122h-2[abx]_2-\\?_5\\*NCCO/3=O",
+  "Neu" = "^Aad21122h-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
+  "Kdn" = "^Aad21122h-2[abx]_2-\\?(?!_5\\*N)",
   "NeuAc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCC/3=O",
   "NeuGc" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*NCCO/3=O",
   "gNeu" = "^Aadxxxxxh-2[abx]_2-\\?_5\\*N(?!CC(O)?/3=O)",
@@ -648,7 +652,7 @@ parse_residue_details <- function(residue) {
       stringr::str_starts(residue, "Aad")
   ) {
     # For Neu5Ac/Neu5Gc, remove the base Kdn structure and the characteristic 5-position modification
-    base_kdn_pattern <- "^Aad21122h-2[abx]_2-6"
+    base_kdn_pattern <- "^Aad21122h-2[abx]_2-(?:6|\\?)"
     if (mono == "Neu5Ac") {
       # Remove the base Kdn pattern and the 5*NCC/3=O
       sub_code <- stringr::str_remove(residue, base_kdn_pattern)

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -5,6 +5,8 @@
 #' For more information about WURCS, see [WURCS](https://github.com/glycoinfo/WURCS/wiki).
 #' Alditol residues are parsed as regular reducing-end glycans with unknown
 #' anomer configurations.
+#' Ambiguous alternative linkage groups are represented as floating glycan
+#' parts when their child residue or subtree is not localized to one parent.
 #'
 #' @param x A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
@@ -130,10 +132,10 @@ WURCS_MONO_REGEX <- c(
   "Par" = "^a2d22m-1[abx]_1-5",
   "Dig" = "^ad222m-1[abx]_1-5",
   "Col" = "^a1d21m-1[abx]_1-5",
-  "Ara" = "^a211h-1[abx]_1-5",
-  "Lyx" = "^a221h-1[abx]_1-5",
-  "Xyl" = "^a212h-1[abx]_1-5",
-  "Rib" = "^a222h-1[abx]_1-5",
+  "Ara" = "^a211h-1[abx]_1-[45]",
+  "Lyx" = "^a221h-1[abx]_1-[45]",
+  "Xyl" = "^a212h-1[abx]_1-[45]",
+  "Rib" = "^a222h-1[abx]_1-[45]",
 
   # Neu5Ac and Neu5Gc - match if contains _5*NCC/3=O or _5*NCCO/3=O anywhere in the string
   # These must come before Kdn since they are more specific
@@ -780,10 +782,78 @@ parse_linkages <- function(x) {
 }
 
 
-parse_one_linkage <- function(x) {
+parse_wurcs_linkages <- function(x, residues) {
+  linkages <- stringr::str_split_1(x, "_")
+  floating <- stringr::str_detect(linkages, stringr::fixed("}"))
+
+  list(
+    ordinary = purrr::map(
+      linkages[!floating],
+      parse_one_linkage,
+      anomers = purrr::map_chr(residues, "anomer")
+    ),
+    floating = purrr::map(linkages[floating], parse_wurcs_floating_linkage)
+  )
+}
+
+
+parse_wurcs_floating_linkage <- function(x) {
+  linkage <- stringr::str_remove(x, stringr::fixed("}"))
+  parts <- stringr::str_split_1(linkage, stringr::fixed("-"))
+  if (length(parts) != 2L) {
+    cli::cli_abort(
+      "Floating WURCS substituents are not supported: {.str {x}}"
+    )
+  }
+
+  child <- parse_wurcs_linkage_endpoint(parts[[1]])
+  candidates <- purrr::map(
+    stringr::str_split_1(parts[[2]], stringr::fixed("|")),
+    parse_wurcs_linkage_endpoint
+  )
+  candidate_nodes <- purrr::map_int(candidates, "node")
+  positions_by_parent <- split(
+    purrr::map_chr(candidates, "position"),
+    candidate_nodes
+  )
+  position_sets <- unique(purrr::map_chr(
+    positions_by_parent,
+    ~ paste(unique(.x), collapse = "/")
+  ))
+  if (length(position_sets) != 1L) {
+    cli::cli_abort(
+      "Floating WURCS linkages with parent-specific acceptor positions are not supported: {.str {x}}"
+    )
+  }
+
+  list(
+    root = child$node,
+    child_position = child$position,
+    parent_positions = unique(purrr::map_chr(candidates, "position")),
+    parents = unique(candidate_nodes)
+  )
+}
+
+
+parse_wurcs_linkage_endpoint <- function(x) {
+  list(
+    node = letter_to_int(stringr::str_sub(x, 1, 1)),
+    position = stringr::str_sub(x, 2, -1)
+  )
+}
+
+
+parse_one_linkage <- function(x, anomers = NULL) {
   # Input: a string of one WURCS linkage, e.g. "a4-b1"
   # Output: a named list of `from`, `to`, and `linkage`
   spl <- stringr::str_split_1(x, "-")
+  if (!is.null(anomers)) {
+    left_donor <- wurcs_endpoint_can_be_donor(spl[[1]], anomers)
+    right_donor <- wurcs_endpoint_can_be_donor(spl[[2]], anomers)
+    if (left_donor && !right_donor) {
+      spl <- rev(spl)
+    }
+  }
 
   handle_parallel_pos <- function(part) {
     if (stringr::str_detect(part, "|")) {
@@ -799,7 +869,10 @@ parse_one_linkage <- function(x) {
 
   from_part <- handle_parallel_pos(spl[[1]])
   to_part <- handle_parallel_pos(spl[[2]])
-  if (stringr::str_detect(to_part, stringr::fixed("/"))) {
+  if (
+    is.null(anomers) &&
+      stringr::str_detect(to_part, stringr::fixed("/"))
+  ) {
     # WURCS has a strange linkage rule:
     # In the normal case, the linkage positions are opposite to the orders of IUPAC.
     # For example, "a4-b1" means "1-4" in IUPAC.
@@ -820,6 +893,16 @@ parse_one_linkage <- function(x) {
     stringr::str_sub(from_part, 2, -1)
   )
   list(from = from_idx, to = to_idx, linkage = linkage)
+}
+
+
+wurcs_endpoint_can_be_donor <- function(endpoint, anomers) {
+  alternatives <- stringr::str_split_1(endpoint, stringr::fixed("|"))
+  node <- letter_to_int(stringr::str_sub(alternatives[[1]], 1, 1))
+  positions <- stringr::str_sub(alternatives, 2, -1)
+  anomer_position <- stringr::str_sub(anomers[[node]], 2, -1)
+
+  any(positions == "?" | positions == anomer_position)
 }
 
 letter_to_int <- function(letter) {
@@ -861,16 +944,78 @@ prepare_graph_dfs <- function(residues, linkages) {
 }
 
 
-build_glycan_graph <- function(edgelist_df, vertex_df) {
+build_glycan_graph <- function(edgelist_df, vertex_df, floating = list()) {
   # For format of input values, see `prepare_graph_dfs`.
   graph <- igraph::graph_from_data_frame(
     edgelist_df,
     vertices = vertex_df[c("name", "mono", "sub")]
   )
-  core_node <- igraph::V(graph)[igraph::degree(graph, mode = "in") == 0]
+  if (length(floating) > 0) {
+    graph <- annotate_wurcs_floating_parts(graph, vertex_df, floating)
+  }
+  floating_roots <- purrr::map_int(floating, "root")
+  core_node <- igraph::V(graph)[
+    igraph::degree(graph, mode = "in") == 0 &
+      !seq_len(igraph::vcount(graph)) %in% floating_roots
+  ]
   core_anomer <- vertex_df$anomer[as.numeric(core_node)]
   graph$anomer <- core_anomer
   graph$alditol <- FALSE # Not implemented yet
+  graph
+}
+
+
+annotate_wurcs_floating_parts <- function(graph, vertex_df, floating) {
+  components <- igraph::components(graph, mode = "weak")$membership
+  floating_components <- components[purrr::map_int(floating, "root")]
+  floating_nodes <- purrr::map(
+    floating_components,
+    ~ as.integer(which(components == .x))
+  )
+  main_vertices <- as.integer(setdiff(
+    seq_len(igraph::vcount(graph)),
+    unlist(floating_nodes, use.names = FALSE)
+  ))
+  occupied_slots <- definitely_occupied_acceptor_slots(
+    graph,
+    main_vertices
+  )
+
+  graph$floating_parts <- purrr::map2(
+    floating,
+    floating_nodes,
+    function(metadata, nodes) {
+      parents <- metadata$parents
+      parents <- intersect(parents, main_vertices)
+      if (length(parents) == 0) {
+        cli::cli_abort(
+          "A WURCS floating part has no candidate parent in the main tree."
+        )
+      }
+
+      linkage <- paste0(
+        stringr::str_sub(vertex_df$anomer[[metadata$root]], 1, 1),
+        metadata$child_position,
+        "-",
+        paste(metadata$parent_positions, collapse = "/")
+      )
+      parents <- normalize_floating_part_parents(
+        parents,
+        main_vertices,
+        linkage,
+        occupied_slots,
+        context = "WURCS floating part"
+      )
+
+      list(
+        root = as.integer(metadata$root),
+        nodes = nodes,
+        linkage = linkage,
+        parents = as.integer(parents)
+      )
+    }
+  )
+
   graph
 }
 
@@ -909,6 +1054,7 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
   # e.g. c(1, 1, 2, 3, 3)
   residue_sequence_part <- stringr::str_extract(x, wurcs_regex, group = 2)
   residue_sequence <- parse_residue_sequence(residue_sequence_part)
+  residues <- unique_residues[residue_sequence]
 
   # linkages: a list of named lists, each list contains `from`, `to`, and `linkage`.
   # `from` and `to` are the indices of monosaccharides in the sequence.
@@ -916,12 +1062,18 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
   linkage_part <- stringr::str_extract(x, wurcs_regex, group = 3)
   if (linkage_part == "") {
     linkages <- NULL
+    floating <- list()
   } else {
-    linkages <- parse_linkages(linkage_part)
+    linkage_data <- parse_wurcs_linkages(linkage_part, residues)
+    linkages <- linkage_data$ordinary
+    floating <- linkage_data$floating
   }
 
-  residues <- unique_residues[residue_sequence]
   graph_dfs <- prepare_graph_dfs(residues, linkages)
-  graph <- build_glycan_graph(graph_dfs$edgelist, graph_dfs$vertex)
+  graph <- build_glycan_graph(
+    graph_dfs$edgelist,
+    graph_dfs$vertex,
+    floating = floating
+  )
   graph
 }

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -35,18 +35,16 @@ This function parses GlycoCT strings into a \code{\link[glyrepr:glycan_structure
 GlycoCT is a format used by databases like GlyTouCan and GlyGen.
 }
 \details{
-GlycoCT format consists of two parts:
+GlycoCT format consists of:
 \itemize{
 \item RES: Contains monosaccharides (lines starting with 'b:') and substituents (lines starting with 's:')
 \item LIN: Contains linkage information between residues
+\item UND: Contains floating substructures whose attachment to the main glycan
+is unresolved
 }
 
 Alditol residues are parsed as regular reducing-end glycans with unknown
 anomer configurations.
-
-GlycoCT \code{UND} sections are not currently supported. Inputs containing an
-underdetermined subgraph fail according to \code{on_failure} instead of returning
-an incomplete connected core.
 
 For more information about GlycoCT format, see the glycoct.md documentation.
 }

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -36,6 +36,8 @@ Currently, only WURCS 2.0 is supported.
 For more information about WURCS, see \href{https://github.com/glycoinfo/WURCS/wiki}{WURCS}.
 Alditol residues are parsed as regular reducing-end glycans with unknown
 anomer configurations.
+Ambiguous alternative linkage groups are represented as floating glycan
+parts when their child residue or subtree is not localized to one parent.
 }
 \examples{
 wurcs <- paste0(

--- a/tests/testthat/_snaps/parse-glycoct.md
+++ b/tests/testthat/_snaps/parse-glycoct.md
@@ -1,3 +1,11 @@
+# GlycoCT UND donor alternatives fail explicitly
+
+    Code
+      parse_glycoct_und_block(und)
+    Condition
+      Error in `parse_glycoct_und_block()`:
+      ! GlycoCT UND linkages with alternative donor positions are not supported: "o(3+1|2)d"
+
 # GlycoCT UND parts require a feasible candidate parent
 
     Code

--- a/tests/testthat/_snaps/parse-glycoct.md
+++ b/tests/testthat/_snaps/parse-glycoct.md
@@ -1,0 +1,8 @@
+# GlycoCT UND parts require a feasible candidate parent
+
+    Code
+      filter_glycoct_und_parents(1L, "b1-3", "1\r3")
+    Condition
+      Error in `filter_glycoct_und_parents()`:
+      ! No feasible parent remains for a GlycoCT UND part after excluding occupied acceptor positions.
+

--- a/tests/testthat/_snaps/parse-glycoct.md
+++ b/tests/testthat/_snaps/parse-glycoct.md
@@ -1,9 +1,0 @@
-# GlycoCT rejects unsupported UND sections without losing residues
-
-    Code
-      parse_glycoct(with_und)
-    Condition
-      Error in `parse_glycoct()`:
-      ! Can't parse GlycoCT with unsupported `UND` sections.
-      i Returning only the connected `RES`/`LIN` core would lose underdetermined residues.
-

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -640,3 +640,34 @@ test_that("single-parent GlycoCT UND sections become ordinary edges", {
   expect_identical(unname(as.character(result)), "Neu5Ac(a2-3)Gal(a1-")
   expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
 })
+
+test_that("GlycoCT UND candidate parents exclude occupied acceptor slots", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(3+1)d",
+    "RES",
+    "3b:a-lgal-HEX-1:5|6:d"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(
+    unname(as.character(result)),
+    "Fuc(a1-3)Glc(b1-3)Gal(a1-"
+  )
+  expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
+})
+
+test_that("GlycoCT UND parts require a feasible candidate parent", {
+  expect_snapshot(
+    error = TRUE,
+    filter_glycoct_und_parents(1L, "b1-3", "1\r3")
+  )
+})

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -641,6 +641,21 @@ test_that("single-parent GlycoCT UND sections become ordinary edges", {
   expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
 })
 
+test_that("GlycoCT UND donor alternatives fail explicitly", {
+  und <- c(
+    "UND1:100.0:100.0",
+    "ParentIDs:1",
+    "SubtreeLinkageID1:o(3+1|2)d",
+    "RES",
+    "2b:a-lgal-HEX-1:5|6:d"
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    parse_glycoct_und_block(und)
+  )
+})
+
 test_that("GlycoCT UND candidate parents exclude occupied acceptor slots", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -29,38 +29,6 @@ test_that("GlycoCT accepts space-separated records", {
   expect_equal(result, "Gal(b1-3)GalNAc(a1-")
 })
 
-test_that("GlycoCT rejects unsupported UND sections without losing residues", {
-  core <- paste0(
-    "RES\n",
-    "1b:b-dglc-HEX-1:5\n",
-    "2s:n-acetyl\n",
-    "LIN\n",
-    "1:1d(2+1)2n"
-  )
-  with_und <- paste0(
-    core,
-    "\nUND\n",
-    "UND1:100.0:100.0\n",
-    "ParentIDs:1\n",
-    "SubtreeLinkageID1:x(-1+1)x\n",
-    "RES\n",
-    "3b:a-lgal-HEX-1:5|6:d"
-  )
-
-  expect_snapshot(error = TRUE, parse_glycoct(with_und))
-
-  result <- parse_glycoct(
-    c(core = core, underdetermined = with_und),
-    on_failure = "na"
-  )
-  expect_equal(
-    as.character(result),
-    c(core = "GlcNAc(b1-", underdetermined = NA)
-  )
-
-  expect_identical(is.na(auto_parse(with_und, on_failure = "na")), TRUE)
-})
-
 test_that("GlycoCT maps generic HEX descriptors", {
   expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-x:x")), "Hex(??-")
   expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-1:x|6:d")), "dHex(?1-")
@@ -613,4 +581,62 @@ test_that("GlycoCT: a complex N-glycan example", {
   result <- as.character(parse_glycoct(glycoct))
   expected <- "Neu5Ac(a2-3/6)Gal(b1-4)GlcNAc(b1-2)Man(a1-3)[Gal(b1-4)GlcNAc(b1-2)Man(a1-6)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
   expect_equal(result, expected)
+})
+
+test_that("GlycoCT UND sections become floating glycan parts", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(6+1)d",
+    "RES",
+    "3b:b-dglc-HEX-1:5",
+    "4s:n-acetyl",
+    "5b:b-dgal-HEX-1:5",
+    "LIN",
+    "2:3d(2+1)4n",
+    "3:3o(4+1)5d",
+    "UND2:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(2+1)d",
+    "RES",
+    "6b:a-lgal-HEX-1:5|6:d"
+  )
+
+  result <- parse_glycoct(glycoct)
+  floating <- glyrepr::structure_floating_parts(result)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Fuc(a1-2)|1,2}{Gal(b1-4)GlcNAc(b1-6)|1,2}Glc(b1-3)Gal(a1-"
+  )
+  expect_identical(floating$linkage, c("a1-2", "b1-6"))
+  expect_equal(floating$nodes, list(1L, c(2L, 3L)))
+  expect_equal(floating$parents, list(c(4L, 5L), c(4L, 5L)))
+})
+
+test_that("single-parent GlycoCT UND sections become ordinary edges", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1",
+    "SubtreeLinkageID1:o(3+2)d",
+    "RES",
+    "2b:a-dgro-dgal-NON-2:6|1:a|2:keto|3:d",
+    "3s:n-acetyl",
+    "LIN",
+    "7:2d(5+1)3n"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(unname(as.character(result)), "Neu5Ac(a2-3)Gal(a1-")
+  expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
 })

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -613,11 +613,11 @@ test_that("GlycoCT UND sections become floating glycan parts", {
 
   expect_identical(
     unname(as.character(result)),
-    "{Fuc(a1-2)|1,2}{Gal(b1-4)GlcNAc(b1-6)|1,2}Glc(b1-3)Gal(a1-"
+    "{Fuc(a1-2)}{Gal(b1-4)GlcNAc(b1-6)}Glc(b1-3)Gal(a1-"
   )
   expect_identical(floating$linkage, c("a1-2", "b1-6"))
   expect_equal(floating$nodes, list(1L, c(2L, 3L)))
-  expect_equal(floating$parents, list(c(4L, 5L), c(4L, 5L)))
+  expect_equal(floating$parents, list(integer(), integer()))
 })
 
 test_that("single-parent GlycoCT UND sections become ordinary edges", {
@@ -646,23 +646,55 @@ test_that("GlycoCT UND candidate parents exclude occupied acceptor slots", {
     "RES",
     "1b:a-dgal-HEX-1:5",
     "2b:b-dglc-HEX-1:5",
+    "3b:a-dman-HEX-1:5",
     "LIN",
     "1:1o(3+1)2d",
+    "2:1o(4+1)3d",
     "UND",
     "UND1:100.0:100.0",
     "ParentIDs:1|2",
     "SubtreeLinkageID1:o(3+1)d",
     "RES",
-    "3b:a-lgal-HEX-1:5|6:d"
+    "4b:a-lgal-HEX-1:5|6:d"
   )
 
   result <- parse_glycoct(glycoct)
 
   expect_identical(
     unname(as.character(result)),
-    "Fuc(a1-3)Glc(b1-3)Gal(a1-"
+    "Fuc(a1-3)Glc(b1-3)[Man(a1-4)]Gal(a1-"
   )
   expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
+})
+
+test_that("all-main GlycoCT UND candidates become implicit", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(3+2)d",
+    "RES",
+    "3b:a-dgro-dgal-NON-2:6|1:a|2:keto|3:d",
+    "4s:n-acetyl",
+    "LIN",
+    "2:3d(5+1)4n"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Neu5Ac(a2-3)}Glc(b1-3)Gal(a1-"
+  )
+  expect_equal(
+    glyrepr::structure_floating_parts(result)$parents,
+    list(integer())
+  )
 })
 
 test_that("GlycoCT UND parts require a feasible candidate parent", {

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -620,6 +620,25 @@ test_that("GlycoCT UND sections become floating glycan parts", {
   expect_equal(floating$parents, list(integer(), integer()))
 })
 
+test_that("GlycoCT warns for alditols inside UND sections", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1",
+    "SubtreeLinkageID1:o(3+1)d",
+    "RES",
+    "2b:o-dglc-HEX-0:0|1:aldi"
+  )
+
+  expect_warning(
+    result <- parse_glycoct(glycoct),
+    "regular reducing-end glycans with unknown anomer configurations"
+  )
+  expect_identical(unname(as.character(result)), "Glc(?1-3)Gal(a1-")
+})
+
 test_that("single-parent GlycoCT UND sections become ordinary edges", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -661,6 +661,35 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
 })
 
 
+test_that("parse_residue handles generic nonulosonic acids", {
+  expect_equal(
+    parse_residue("Aadxxxxxh-2x_2-6_5*NCC/3=O"),
+    c(mono = "NeuAc", anomer = "?2", sub = "")
+  )
+  expect_equal(
+    parse_residue("Aadxxxxxh-2a_2-6_5*NCCO/3=O"),
+    c(mono = "NeuGc", anomer = "a2", sub = "")
+  )
+  expect_equal(
+    parse_residue("AUdxxxxxh_5*N"),
+    c(mono = "gNeu", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("AUdxxxxxh"),
+    c(mono = "gKdn", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("hUdxxxxxh_5*NCC/3=O"),
+    c(mono = "NeuAc", anomer = "?2", sub = "")
+  )
+
+  result <- parse_wurcs(
+    "WURCS=2.0/1,1,0/[AUdxxxxxh_5*NCC/3=O]/1/"
+  )
+  expect_identical(unname(as.character(result)), "NeuAc(??-")
+})
+
+
 test_that("parse_residue handles unknown ring closure", {
   expect_unknown_ring_residue <- function(residue, mono, sub = "") {
     expect_equal(

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1129,6 +1129,22 @@ test_that("parse_wurcs supports implicit floating parts", {
   )
 })
 
+test_that("parse_wurcs compares floating acceptor positions as sets", {
+  wurcs <- paste0(
+    "WURCS=2.0/3,3,2/",
+    "[a2122h-1x_1-5][a2112h-1b_1-5]",
+    "[Aad21122h-2a_2-6_5*NCC/3=O]/",
+    "1-2-3/a4-b1_c2-a3|a6|b6|b3}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Neu5Ac(a2-3/6)}Gal(b1-4)Glc(?1-"
+  )
+})
+
 
 test_that("parse_wurcs supports floating parts without ordinary linkages", {
   wurcs <- paste0(

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1070,6 +1070,23 @@ test_that("parse_wurcs supports implicit floating parts", {
 })
 
 
+test_that("parse_wurcs supports floating parts without ordinary linkages", {
+  wurcs <- paste0(
+    "WURCS=2.0/2,2,1/",
+    "[a2122h-1x_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/",
+    "1-2/b2-a6}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "Neu5Ac(a2-6)Glc(?1-"
+  )
+  expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
+})
+
+
 test_that("parse_wurcs preserves multiple floating subtrees", {
   wurcs <- paste0(
     "WURCS=2.0/4,5,4/",
@@ -1147,6 +1164,12 @@ test_that("parse_wurcs handles ambiguous u residues", {
       "WURCS=2.0/2,2,1/[u2122A][a2122h-1x_1-5_2*NCC/3=O]/1-2/a?-b1"
     )),
     "GlcNAc(?1-?)GlcA(??-"
+  )
+  expect_equal(
+    as.character(parse_wurcs(
+      "WURCS=2.0/2,2,1/[u2112h][a2122h-1x_1-5]/1-2/a2-b3|b4"
+    )),
+    "Gal(?2-3/4)Glc(?1-"
   )
 })
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -208,6 +208,10 @@ test_that("parse_residue works for each monosaccharide without substituents", {
     c(mono = "Xyl", anomer = "a1", sub = "")
   )
   expect_equal(
+    parse_residue("a212h-1x_1-4"),
+    c(mono = "Xyl", anomer = "?1", sub = "")
+  )
+  expect_equal(
     parse_residue("a222h-1a_1-5"),
     c(mono = "Rib", anomer = "a1", sub = "")
   )
@@ -1042,6 +1046,86 @@ test_that("parse_wurcs correctly handles unknown linkages", {
     )),
     "Gal(a?-3)GalNAc(a1-"
   )
+})
+
+
+test_that("parse_wurcs supports implicit floating parts", {
+  wurcs <- paste0(
+    "WURCS=2.0/3,3,2/",
+    "[a2122h-1x_1-5][a2112h-1b_1-5]",
+    "[Aad21122h-2a_2-6_5*NCC/3=O]/",
+    "1-2-3/a4-b1_c2-a6|b6}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Neu5Ac(a2-6)}Gal(b1-4)Glc(?1-"
+  )
+  expect_equal(
+    glyrepr::structure_floating_parts(result)$parents,
+    list(integer())
+  )
+})
+
+
+test_that("parse_wurcs preserves multiple floating subtrees", {
+  wurcs <- paste0(
+    "WURCS=2.0/4,5,4/",
+    "[a2122h-1x_1-5][a2112h-1b_1-5]",
+    "[a2122h-1b_1-5_2*NCC/3=O][a1221m-1a_1-5]/",
+    "1-2-3-2-4/a4-b1_c4-d1_c1-a3|b3}_e1-a6|b6}"
+  )
+
+  result <- parse_wurcs(wurcs)
+  floating <- glyrepr::structure_floating_parts(result)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Fuc(a1-6)}{Gal(b1-4)GlcNAc(b1-3)}Gal(b1-4)Glc(?1-"
+  )
+  expect_equal(floating$nodes, list(1L, c(2L, 3L)))
+  expect_equal(floating$parents, list(integer(), integer()))
+})
+
+
+test_that("parse_wurcs orients uncertain edges inside floating subtrees", {
+  wurcs <- paste0(
+    "WURCS=2.0/4,4,3/",
+    "[a2122h-1x_1-5][a2112h-1x_1-5]",
+    "[a2122h-1b_1-5_2*NCC/3=O][a1122h-1a_1-5]/",
+    "1-2-3-4/a4-d1_b?-c4_c1-a3|b3|c3|d3}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{Gal(??-4)GlcNAc(b1-3)}Man(a1-4)Glc(?1-"
+  )
+  expect_equal(
+    glyrepr::structure_floating_parts(result)$parents,
+    list(integer())
+  )
+})
+
+
+test_that("parse_wurcs removes occupied explicit parents", {
+  wurcs <- paste0(
+    "WURCS=2.0/4,4,3/",
+    "[a2112h-1x_1-5][a2122h-1b_1-5]",
+    "[a1122h-1a_1-5][a1221m-1a_1-5]/",
+    "1-2-3-4/a4-b1_a3-c1_d1-a3|b3}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "Fuc(a1-3)Glc(b1-4)[Man(a1-3)]Gal(?1-"
+  )
+  expect_identical(unname(glyrepr::has_floating_parts(result)), FALSE)
 })
 
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -717,6 +717,11 @@ test_that("parse_residue normalizes supported 1-4 ring closures", {
 
 
 test_that("parse_residue handles unknown ring closure", {
+  expect_equal(
+    parse_residue("Aad21122h-2x_2-?_5*NCC/3=O"),
+    c(mono = "Neu5Ac", anomer = "?2", sub = "")
+  )
+
   expect_unknown_ring_residue <- function(residue, mono, sub = "") {
     expect_equal(
       parse_residue(residue),

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -690,6 +690,32 @@ test_that("parse_residue handles generic nonulosonic acids", {
 })
 
 
+test_that("parse_residue normalizes supported 1-4 ring closures", {
+  expect_equal(
+    parse_residue("a2112h-1a_1-4"),
+    c(mono = "Gal", anomer = "a1", sub = "")
+  )
+  expect_equal(
+    parse_residue("a2112h-1x_1-4_2*NCC/3=O"),
+    c(mono = "GalNAc", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("axxxxh-1x_1-4"),
+    c(mono = "Hex", anomer = "?1", sub = "")
+  )
+
+  result <- parse_wurcs(paste0(
+    "WURCS=2.0/2,3,2/",
+    "[a2112h-1b_1-5][a2112h-1a_1-4]/",
+    "1-2-2/a4-b1_b2-c1"
+  ))
+  expect_identical(
+    unname(as.character(result)),
+    "Gal(a1-2)Gal(a1-4)Gal(b1-"
+  )
+})
+
+
 test_that("parse_residue handles unknown ring closure", {
   expect_unknown_ring_residue <- function(residue, mono, sub = "") {
     expect_equal(

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -737,6 +737,18 @@ test_that("parse_residue handles unknown ring closure", {
     parse_residue("Aad21122h-2x_2-?_5*NCC/3=O"),
     c(mono = "Neu5Ac", anomer = "?2", sub = "")
   )
+  expect_equal(
+    parse_residue("Aad21122h-2a_2-?_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "Neu5Ac", anomer = "a2", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("Aad21122h-2x_2-?_4*OCC/3=O_5*N"),
+    c(mono = "Neu", anomer = "?2", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("Aad21122h-2b_2-6_4*OCC/3=O_5*N"),
+    c(mono = "Neu", anomer = "b2", sub = "4Ac")
+  )
 
   expect_unknown_ring_residue <- function(residue, mono, sub = "") {
     expect_equal(

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -671,6 +671,22 @@ test_that("parse_residue handles generic nonulosonic acids", {
     c(mono = "NeuGc", anomer = "a2", sub = "")
   )
   expect_equal(
+    parse_residue("Aadxxxxxh-2a_2-6_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "NeuAc", anomer = "a2", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("Aadxxxxxh-2x_2-?_4*OCC/3=O_5*NCCO/3=O"),
+    c(mono = "NeuGc", anomer = "?2", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("AUdxxxxxh_4*OCC/3=O_5*N"),
+    c(mono = "gNeu", anomer = "??", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("hUdxxxxxh_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "NeuAc", anomer = "?2", sub = "4Ac")
+  )
+  expect_equal(
     parse_residue("AUdxxxxxh_5*N"),
     c(mono = "gNeu", anomer = "??", sub = "")
   )


### PR DESCRIPTION
## Summary

Add floating-part support to the GlycoCT and WURCS parsers, preserving underdetermined substructures rather than rejecting or discarding them.

## Details

- Parse GlycoCT `UND` subtrees and their candidate parent domains.
- Parse WURCS floating monosaccharides and subtrees, including linkage sections with no ordinary edges.
- Encode unrestricted all-main attachment domains implicitly.
- Exclude candidate parents whose acceptor positions are already occupied.
- Preserve parallel-position orientation for unknown-anomer WURCS donors.
- Compare WURCS floating acceptor alternatives as order-independent sets and reject unrepresentable GlycoCT donor alternatives explicitly.
- Support generic and concrete WURCS sialic acids with intervening modifications before C5 nitrogen, supported `1-4` furanose rings, and sialic acids with unknown ring closure.
- Preserve strict validation at the `glyrepr` representation boundary.

## Corpus audit

- Audited all 59,181 GlycoCT records and all 59,184 WURCS records in `docs/` through parsing, strict graph validation, and canonicalization.
- GlycoCT: 47,949 successes overall; the 5,994-record `UND` subset retained its established 5,546 successes, including 5,544 structures with floating metadata.
- WURCS: success increased from 46,663 to 47,090 records (+427); 30 additional records now reach strict representation validation instead of failing in the parser.
- The paired 5,994-record floating subset remains at 5,488 successes, including 5,486 structures with floating metadata.
- Residual WURCS parser limits are classified as unrooted ambiguous endpoint groups (6,687), unsupported or partially specified residues (2,198), floating substituents (874), unsupported substituents (224), and repeat/composition syntax (116).

## Verification

- `devtools::test()`: 1,142 passed, 0 failed, 0 warnings, 0 skipped.
- `devtools::check()`: 0 errors, 0 warnings, 3 local worktree/clock notes.
