### PR TITLE
Add furanose support across glycan parsers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs.
+* Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)
 * `parse_wurcs()` now supports floating monosaccharides and subtrees, including implicit all-main attachment domains and filtered explicit candidate parents. It also recognizes generic nonulosonic acids and sialic acids with unknown ring closure. (#40)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # glyparse (development version)
 
+* Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs.
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)
-* `parse_wurcs()` now supports floating monosaccharides and subtrees, including implicit all-main attachment domains and filtered explicit candidate parents. It also recognizes supported `1-4` furanose rings, generic nonulosonic acids, and sialic acids with unknown ring closure. (#40)
+* `parse_wurcs()` now supports floating monosaccharides and subtrees, including implicit all-main attachment domains and filtered explicit candidate parents. It also recognizes generic nonulosonic acids and sialic acids with unknown ring closure. (#40)
 * Parser functions now construct structure vectors through `glyrepr`'s low-level graph APIs, avoiding repeated scalar construction for distinct inputs.
 * Parsers that normalize to IUPAC-condensed notation now normalize complete unique vectors and construct them in one call.
 * Graph-based parsers gain `validate` to skip graph validation for trusted inputs (#36).

--- a/R/furanose.R
+++ b/R/furanose.R
@@ -1,0 +1,71 @@
+#' Map ringless concrete monosaccharides to their furanose forms
+#'
+#' @return A named character vector.
+#' @noRd
+furanose_monosaccharide_map <- local({
+  map <- NULL
+
+  function() {
+    if (is.null(map)) {
+      monos <- glyrepr::available_monosaccharides("concrete")
+      furanose <- monos[stringr::str_detect(monos, stringr::fixed("f"))]
+      ringless <- stringr::str_remove(furanose, stringr::fixed("f"))
+      known_ringless <- ringless %in% monos
+      map <<- rlang::set_names(
+        furanose[known_ringless],
+        ringless[known_ringless]
+      )
+    }
+    map
+  }
+})
+
+#' Convert concrete monosaccharides to their furanose forms
+#'
+#' Generic and already-furanose monosaccharides are returned unchanged.
+#'
+#' @param mono A character vector of monosaccharide names.
+#'
+#' @return A character vector.
+#' @noRd
+as_furanose_monosaccharide <- function(mono) {
+  converted <- unname(furanose_monosaccharide_map()[mono])
+  converted[is.na(converted)] <- mono[is.na(converted)]
+  converted
+}
+
+#' Convert concrete furanose monosaccharides to their ringless forms
+#'
+#' @param mono A character vector of monosaccharide names.
+#'
+#' @return A character vector.
+#' @noRd
+as_ringless_monosaccharide <- function(mono) {
+  map <- furanose_monosaccharide_map()
+  converted <- unname(rlang::set_names(names(map), unname(map))[mono])
+  converted[is.na(converted)] <- mono[is.na(converted)]
+  converted
+}
+
+#' Add furanose source labels to a monosaccharide map
+#'
+#' Source formats such as GlyCAM IUPAC and LINUCS insert the ring marker by
+#' replacing the last `p` in a pyranose label with `f`.
+#'
+#' @param map A named character vector from source labels to glyrepr names.
+#'
+#' @return A named character vector containing furanose aliases.
+#' @noRd
+add_furanose_monosaccharide_mappings <- function(map) {
+  mapped <- unname(map)
+  can_convert <- mapped %in%
+    names(furanose_monosaccharide_map()) &
+    stringr::str_detect(names(map), "p")
+  furanose_names <- stringr::str_replace(
+    names(map)[can_convert],
+    "p([^p]*)$",
+    "f\\1"
+  )
+  map[furanose_names] <- as_furanose_monosaccharide(mapped[can_convert])
+  map
+}

--- a/R/furanose.R
+++ b/R/furanose.R
@@ -57,12 +57,19 @@ as_ringless_monosaccharide <- function(mono) {
 #' @return A named character vector containing furanose aliases.
 #' @noRd
 add_furanose_monosaccharide_mappings <- function(map) {
+  source_names <- names(map)
   mapped <- unname(map)
+  ring_suffix <- stringr::str_extract(
+    source_names,
+    "(?<=p)[^p]*$"
+  )
+  has_pyranose_marker <- !is.na(ring_suffix) &
+    (ring_suffix == "" | endsWith(mapped, ring_suffix))
   can_convert <- mapped %in%
     names(furanose_monosaccharide_map()) &
-    stringr::str_detect(names(map), "p")
+    has_pyranose_marker
   furanose_names <- stringr::str_replace(
-    names(map)[can_convert],
+    source_names[can_convert],
     "p([^p]*)$",
     "f\\1"
   )

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -182,7 +182,7 @@ convert_glycam_iupac_mono <- function(mono) {
 #' @return A named character vector mapping GlyCAM labels to glyrepr labels.
 #' @noRd
 glycam_iupac_mono_map <- function() {
-  c(
+  add_furanose_monosaccharide_mappings(c(
     Hexp = "Hex",
     DFucp = "Fuc",
     DGalp = "Gal",
@@ -264,7 +264,7 @@ glycam_iupac_mono_map <- function() {
     DTagp = "Tag",
     LSorp = "Sor",
     DPsip = "Psi"
-  )
+  ))
 }
 
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -2182,6 +2182,9 @@ map_single_mono_ringless <- function(content) {
   if (is_generic_glycoct_hex(content)) {
     return("Hex")
   }
+  if (is_generic_glycoct_pen(content)) {
+    return("Pen")
+  }
 
   # If no exact match, fall back to basic parsing
   parts <- stringr::str_split(content, "-")[[1]]
@@ -2245,6 +2248,19 @@ is_generic_glycoct_hex <- function(content) {
   isTRUE(stringr::str_detect(
     content,
     "^HEX-(?:\\d+|x):(?:\\d+|x)(?:\\|6:d)?$"
+  ))
+}
+
+#' Check whether a GlycoCT content string is a generic pentose
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_generic_glycoct_pen <- function(content) {
+  isTRUE(stringr::str_detect(
+    content,
+    "^PEN-(?:\\d+|x):(?:\\d+|x)$"
   ))
 }
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -329,6 +329,55 @@ extract_glycoct_ring_bounds <- function(content) {
   stringr::str_extract(content, "-((?:\\d+|x):(?:\\d+|x))", group = 1)
 }
 
+#' Parse numeric GlycoCT ring bounds
+#'
+#' @param bounds A GlycoCT ring-bounds string.
+#'
+#' @return An integer vector of length two, or two missing integers.
+#' @noRd
+parse_glycoct_ring_bounds <- function(bounds) {
+  if (is.na(bounds) || stringr::str_detect(bounds, "x")) {
+    return(c(NA_integer_, NA_integer_))
+  }
+  as.integer(stringr::str_split_1(bounds, stringr::fixed(":")))
+}
+
+#' Check whether GlycoCT ring bounds describe a supported cyclic form
+#'
+#' @param bounds A GlycoCT ring-bounds string.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_supported_glycoct_ring_bounds <- function(bounds) {
+  parsed <- parse_glycoct_ring_bounds(bounds)
+  !anyNA(parsed) && parsed[[2]] - parsed[[1]] %in% c(3L, 4L)
+}
+
+#' Check whether GlycoCT content describes a furanose ring
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_glycoct_furanose <- function(content) {
+  bounds <- parse_glycoct_ring_bounds(extract_glycoct_ring_bounds(content))
+  !anyNA(bounds) && identical(bounds[[2]] - bounds[[1]], 3L)
+}
+
+#' Preserve a GlycoCT furanose ring in a mapped monosaccharide
+#'
+#' @param mono A glyrepr monosaccharide name.
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A glyrepr monosaccharide name.
+#' @noRd
+preserve_glycoct_ring <- function(mono, content) {
+  if (is_glycoct_furanose(content)) {
+    return(as_furanose_monosaccharide(mono))
+  }
+  mono
+}
+
 #' Remove the ring-bounds component from a GlycoCT monosaccharide descriptor
 #'
 #' @param content GlycoCT monosaccharide content without the leading anomer.
@@ -1367,9 +1416,14 @@ glycoct_signature_mono_matches <- function(signature, entry) {
   if (is.na(signature$bounds) || is.na(entry$bounds)) {
     return(identical(signature$bounds, entry$bounds))
   }
+  same_ring_family <- is_supported_glycoct_ring_bounds(signature$bounds) &&
+    is_supported_glycoct_ring_bounds(entry$bounds) &&
+    parse_glycoct_ring_bounds(signature$bounds)[[1]] ==
+      parse_glycoct_ring_bounds(entry$bounds)[[1]]
   identical(signature$bounds, entry$bounds) ||
     signature$wildcard_bounds ||
-    entry$wildcard_bounds
+    entry$wildcard_bounds ||
+    same_ring_family
 }
 
 glycoct_signature_key <- function(core, subs, linkages) {
@@ -1555,7 +1609,7 @@ consolidate_residues <- function(residues, linkages, mono_mapping_index) {
             vertices,
             list(list(
               original_id = main_mono_id,
-              mono = matched,
+              mono = preserve_glycoct_ring(matched, main_mono$content),
               sub = "",
               anomer = main_mono$anomer,
               anomer_pos = main_mono$anomer_pos,
@@ -1580,7 +1634,10 @@ consolidate_residues <- function(residues, linkages, mono_mapping_index) {
             vertices,
             list(list(
               original_id = main_mono_id,
-              mono = partial_result$mono,
+              mono = preserve_glycoct_ring(
+                partial_result$mono,
+                main_mono$content
+              ),
               sub = partial_result$sub,
               anomer = main_mono$anomer,
               anomer_pos = main_mono$anomer_pos,
@@ -2093,6 +2150,10 @@ matches_glycoct_pattern <- function(group, residues, linkages, mapping) {
 }
 
 map_single_mono <- function(content) {
+  preserve_glycoct_ring(map_single_mono_ringless(content), content)
+}
+
+map_single_mono_ringless <- function(content) {
   # Extract monosaccharide name from content like "dglc-HEX-1:5" or "lgal-HEX-1:5|6:d"
 
   is_alditol <- is_glycoct_alditol_mono(content)

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -55,6 +55,7 @@ IUPAC_EXT_TO_CON <- local({
   monos <- setdiff(monos, "Sia")
   # Deal with general rules
   ext_monos <- dplyr::case_when(
+    monos %in% unname(furanose_monosaccharide_map()) ~ monos,
     stringr::str_detect(monos, "NAc$") ~ stringr::str_replace(
       monos,
       "NAc$",

--- a/R/parse-linear-code.R
+++ b/R/parse-linear-code.R
@@ -61,6 +61,15 @@ convert_linear_to_iupac <- function(x) {
     "Api" = "P",
     "Fru" = "E"
   )
+  furanose <- as_furanose_monosaccharide(names(mono_map))
+  has_furanose <- furanose != names(mono_map)
+  mono_map <- c(
+    mono_map,
+    rlang::set_names(
+      paste0(unname(mono_map[has_furanose]), "^"),
+      furanose[has_furanose]
+    )
+  )
 
   # Substituent mapping from IUPAC to Linear Code
   sub_map <- c(
@@ -93,7 +102,10 @@ convert_linear_to_iupac <- function(x) {
   # ===== Convert monosaccharides =====
   # "A(b1-3)A_2P_(b1-3)[A(b1-4)]G(b1-" will be converted to "Gal(b1-3)Gal_2P_(b1-3)[Gal(b1-4)]Glc(b1-"
 
-  mono_patterns <- stringr::str_glue("(?<![:alnum:]|\\?){mono_map}(?=[_\\(])")
+  mono_codes <- purrr::map_chr(unname(mono_map), stringr::str_escape)
+  mono_patterns <- stringr::str_glue(
+    "(?<![:alnum:]|\\?){mono_codes}(?=[_\\(])"
+  )
   mono_replaces <- names(mono_map)
   for (i in seq_along(mono_patterns)) {
     x <- stringr::str_replace_all(x, mono_patterns[i], mono_replaces[i])

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -298,7 +298,7 @@ match_linucs_mono_stem <- function(x) {
 #' @return A named character vector.
 #' @noRd
 linucs_mono_stem_map <- function() {
-  c(
+  add_furanose_monosaccharide_mappings(c(
     `6-deoxy-HexpNAc` = "dHexNAc",
     `6-deoxy-HexNAc` = "dHexNAc",
     HexpNAc = "HexNAc",
@@ -400,7 +400,7 @@ linucs_mono_stem_map <- function() {
     `D-Tagp` = "Tag",
     `L-Sorp` = "Sor",
     `D-Psip` = "Psi"
-  )
+  ))
 }
 
 
@@ -458,7 +458,7 @@ parse_linucs_residue_substituents <- function(x, mono) {
 #' @return A character vector of glyrepr monosaccharide names.
 #' @noRd
 linucs_n_sulfate_monos <- function() {
-  c(
+  monos <- c(
     "HexN",
     "GlcN",
     "ManN",
@@ -469,6 +469,7 @@ linucs_n_sulfate_monos <- function() {
     "TalN",
     "IdoN"
   )
+  c(monos, as_furanose_monosaccharide(monos))
 }
 
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -577,11 +577,13 @@ parse_residue_details <- function(residue) {
   #        for multiple substituents, they are separated by commas, e.g. "3Me,6S"
 
   is_alditol <- FALSE
-  matching_residue <- stringr::str_replace(
+  is_furanose <- stringr::str_detect(
     residue,
-    "(-1[abx]_1)-4",
-    "\\1-5"
+    "-(?:1[abx]_1-4|2[abx]_2-5)(?:_|$)"
   )
+  matching_residue <- residue |>
+    stringr::str_replace("(-1[abx]_1)-4", "\\1-5") |>
+    stringr::str_replace("(-2[abx]_2)-5", "\\1-6")
 
   # Get monosaacharide name
   mono_idx <- detect_wurcs_pattern(
@@ -649,20 +651,20 @@ parse_residue_details <- function(residue) {
     mono %in%
       c("Neu5Ac", "Neu5Gc", "Neu") &&
       !is_alditol &&
-      stringr::str_starts(residue, "Aad")
+      stringr::str_starts(matching_residue, "Aad")
   ) {
     # For Neu5Ac/Neu5Gc, remove the base Kdn structure and the characteristic 5-position modification
     base_kdn_pattern <- "^Aad21122h-2[abx]_2-(?:6|\\?)"
     if (mono == "Neu5Ac") {
       # Remove the base Kdn pattern and the 5*NCC/3=O
-      sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+      sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
     } else if (mono == "Neu5Gc") {
       # Remove the base Kdn pattern and the 5*NCCO/3=O
-      sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+      sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
     } else {
-      sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+      sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(
         sub_code,
         "_5\\*N(?!CC(O)?/3=O)"
@@ -671,10 +673,10 @@ parse_residue_details <- function(residue) {
   } else if (
     mono %in%
       c("Neu5Ac", "Neu5Gc", "Neu") &&
-      stringr::str_starts(residue, "AUd")
+      stringr::str_starts(matching_residue, "AUd")
   ) {
     base_kdn_pattern <- "^AUd21122h"
-    sub_code <- stringr::str_remove(residue, base_kdn_pattern)
+    sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
     if (mono == "Neu5Ac") {
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
     } else if (mono == "Neu5Gc") {
@@ -731,6 +733,10 @@ parse_residue_details <- function(residue) {
 
     # Join multiple substituents with commas
     sub <- paste(substituents, collapse = ",")
+  }
+
+  if (is_furanose) {
+    mono <- as_furanose_monosaccharide(mono)
   }
 
   list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,21 +1,8 @@
-# The anomer positions are fix for known monosaccharides.
-# Except for the monosaccharides with C2 anomer, all others are on C1.
+# The anomer positions are fixed for concrete monosaccharides.
+# Generic monosaccharides default to C1.
 decide_anomer_pos <- function(mono) {
-  anomer_on_pos2 <- c(
-    "Neu5Ac",
-    "Neu5Gc",
-    "Neu",
-    "Kdn",
-    "Pse",
-    "Leg",
-    "Aci",
-    "4eLeg",
-    "Kdo",
-    "Dha",
-    "Fru",
-    "Tag",
-    "Sor",
-    "Psi"
-  )
-  dplyr::if_else(mono %in% anomer_on_pos2, "2", "1")
+  anomer_pos <- rep("1", length(mono))
+  concrete <- mono %in% glyrepr::available_monosaccharides("concrete")
+  anomer_pos[concrete] <- glyrepr::get_anomer_pos(mono[concrete])
+  anomer_pos
 }

--- a/tests/testthat/test-auto-parse.R
+++ b/tests/testthat/test-auto-parse.R
@@ -47,6 +47,17 @@ test_that("auto_parse correctly identifies and parses Linear Code format", {
   expect_equal(as.character(result), as.character(expected))
 })
 
+test_that("auto_parse preserves furanose rings", {
+  input <- c("Galf(b1-3)GlcfNAc(b1-", "A^b3G^b")
+
+  result <- auto_parse(input)
+
+  expect_identical(
+    as.character(result),
+    c("Galf(b1-3)GlcfNAc(b1-", "Galf(b1-3)Glcf(b1-")
+  )
+})
+
 test_that("auto_parse correctly identifies and parses LINUCS format", {
   input <- "[][b-D-Glcp]{[(4+1)][b-D-Galp]{}}"
   result <- auto_parse(input)

--- a/tests/testthat/test-furanose.R
+++ b/tests/testthat/test-furanose.R
@@ -16,3 +16,13 @@ test_that("IUPAC-condensed parses every furanose monosaccharide", {
 
   expect_identical(as.character(parsed), input)
 })
+
+test_that("furanose aliases replace only pyranose ring markers", {
+  glycam_map <- glycam_iupac_mono_map()
+  linucs_map <- linucs_mono_stem_map()
+
+  expect_identical(unname(glycam_map[["DApif"]]), "Apif")
+  expect_identical(unname(linucs_map[["D-Apif"]]), "Apif")
+  expect_false("DAfif" %in% names(glycam_map))
+  expect_false("D-Afif" %in% names(linucs_map))
+})

--- a/tests/testthat/test-furanose.R
+++ b/tests/testthat/test-furanose.R
@@ -1,0 +1,18 @@
+test_that("furanose helpers cover every concrete monosaccharide", {
+  map <- furanose_monosaccharide_map()
+  concrete <- glyrepr::available_monosaccharides("concrete")
+
+  expect_setequal(c(names(map), unname(map)), concrete)
+  expect_identical(as_furanose_monosaccharide(names(map)), unname(map))
+  expect_identical(as_ringless_monosaccharide(unname(map)), names(map))
+})
+
+test_that("IUPAC-condensed parses every furanose monosaccharide", {
+  furanose <- unname(furanose_monosaccharide_map())
+  anomer_pos <- glyrepr::get_anomer_pos(furanose)
+  input <- paste0(furanose, "(?", anomer_pos, "-")
+
+  parsed <- parse_iupac_condensed(input)
+
+  expect_identical(as.character(parsed), input)
+})

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -171,13 +171,26 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
       MurNAc = "MurNAc(b1-",
       MurNGc = "MurNGc(b1-",
       Mur = "Mur(b1-",
-      Api = "Api(b1-",
+      Api = "Apif(b1-",
       Fru = "Fru(b2-",
       Tag = "Tag(b2-",
       Sor = "Sor(b2-",
       Psi = "Psi(b2-"
     )
   )
+})
+
+test_that("GlyCAM IUPAC parses every furanose monosaccharide", {
+  furanose <- unname(furanose_monosaccharide_map())
+  mono_map <- glycam_iupac_mono_map()
+  source_names <- names(mono_map)[match(furanose, mono_map)]
+  anomer_pos <- glyrepr::get_anomer_pos(furanose)
+  input <- paste0(source_names, "?", anomer_pos, "-OH")
+
+  parsed <- parse_glycam_iupac(input)
+  graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
+
+  expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
 })
 
 test_that("GlyCAM IUPAC converts residue modifiers", {

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -193,6 +193,10 @@ test_that("GlyCAM IUPAC parses every furanose monosaccharide", {
   expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
 })
 
+test_that("GlyCAM IUPAC rejects malformed Api furanose aliases", {
+  expect_error(parse_glycam_iupac("DAfifb1-OH"), "Can't parse")
+})
+
 test_that("GlyCAM IUPAC converts residue modifiers", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -13,6 +13,31 @@ test_that("GlycoCT: Gal(b1-3)GalNAc(a1-", {
   expect_equal(result, expected)
 })
 
+test_that("GlycoCT preserves furanose ring bounds", {
+  glcfnac <- paste0(
+    "RES\n",
+    "1b:b-dglc-HEX-1:4\n",
+    "2s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
+  )
+  neuf5ac <- paste0(
+    "RES\n",
+    "1b:a-dgro-dgal-NON-2:5|1:a|2:keto|3:d\n",
+    "2s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(5+1)2n"
+  )
+  fruf <- "RES\n1b:b-dara-HEX-2:5|2:keto"
+
+  parsed <- parse_glycoct(c(glcfnac, neuf5ac, fruf))
+
+  expect_identical(
+    as.character(parsed),
+    c("GlcfNAc(b1-", "Neuf5Ac(a2-", "Fruf(b2-")
+  )
+})
+
 test_that("GlycoCT accepts space-separated records", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -78,6 +78,11 @@ test_that("GlycoCT maps generic HEX descriptors", {
   expect_equal(as.character(parse_glycoct(hexnac_6s)), "HexNAc6S(?1-")
 })
 
+test_that("GlycoCT maps generic PEN descriptors", {
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-PEN-x:x")), "Pen(??-")
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-PEN-1:4")), "Pen(?1-")
+})
+
 test_that("GlycoCT maps generic Neu5Ac descriptors", {
   neu5ac <- paste0(
     "RES\n",

--- a/tests/testthat/test-parse-iupac-compact.R
+++ b/tests/testthat/test-parse-iupac-compact.R
@@ -51,6 +51,18 @@ test_that("IUPAC-compact vectorizes terminal anomer positions", {
   expect_identical(as.character(parsed), c("Glc(b1-", "Neu5Ac(a2-"))
 })
 
+test_that("IUPAC-compact parses every furanose monosaccharide", {
+  furanose <- unname(furanose_monosaccharide_map())
+  anomer_pos <- glyrepr::get_anomer_pos(furanose)
+
+  parsed <- parse_iupac_compact(furanose)
+
+  expect_identical(
+    as.character(parsed),
+    paste0(furanose, "(?", anomer_pos, "-")
+  )
+})
+
 test_that("IUPAC-compact supports on_failure handling", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-iupac-extended.R
+++ b/tests/testthat/test-parse-iupac-extended.R
@@ -16,6 +16,18 @@ test_that("monosaccharides are parsed correctly", {
   expect_mono("D-gro-α-D-manHepp-(1→", "DDmanHep")
 })
 
+test_that("every furanose monosaccharide is parsed correctly", {
+  furanose <- unname(furanose_monosaccharide_map())
+  extended <- names(IUPAC_EXT_TO_CON)[match(furanose, IUPAC_EXT_TO_CON)]
+  anomer_pos <- glyrepr::get_anomer_pos(furanose)
+  input <- paste0("?-D-", extended, "-(", anomer_pos, "→")
+
+  parsed <- parse_iupac_extended(input)
+  graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
+
+  expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
+})
+
 
 test_that("plain text format is parsed correctly", {
   expect_mono <- function(iupac_ext, mono) {

--- a/tests/testthat/test-parse-iupac-short.R
+++ b/tests/testthat/test-parse-iupac-short.R
@@ -11,6 +11,18 @@ test_that("Monosaccharides are correctly parsed", {
   expect_mono("Neu5Aca-", "Neu5Ac")
 })
 
+test_that("furanose monosaccharides are correctly parsed", {
+  furanose <- unname(furanose_monosaccharide_map())
+  anomer_pos <- glyrepr::get_anomer_pos(furanose)
+
+  parsed <- parse_iupac_short(paste0(furanose, "?-"))
+
+  expect_identical(
+    as.character(parsed),
+    paste0(furanose, "(?", anomer_pos, "-")
+  )
+})
+
 
 test_that("generic monosaccharides are parsed correctly", {
   expect_mono <- function(x, mono) {

--- a/tests/testthat/test-parse-kcf.R
+++ b/tests/testthat/test-parse-kcf.R
@@ -155,6 +155,23 @@ test_that("KCF parses a single monosaccharide", {
   expect_equal(result, "Glc(?1-")
 })
 
+test_that("KCF parses every furanose monosaccharide label", {
+  furanose <- unname(furanose_monosaccharide_map())
+  records <- paste0(
+    "ENTRY       test                      Glycan\n",
+    "NODE        1\n",
+    "            1   ",
+    furanose,
+    "         0     0\n",
+    "///"
+  )
+
+  parsed <- parse_kcf(records)
+  graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
+
+  expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
+})
+
 test_that("KCF parser preserves wrapper behavior", {
   kcf <- paste0(
     "ENTRY       G00000                      Glycan\n",

--- a/tests/testthat/test-parse-linear-code.R
+++ b/tests/testthat/test-parse-linear-code.R
@@ -42,6 +42,19 @@ test_that("Linear Code mono names are parsed correctly", {
   expect_equal(as.character(parse_linear_code("Ea")), "Fru(a2-")
 })
 
+test_that("Linear Code caret modifiers preserve furanose rings", {
+  parsed <- parse_linear_code(c("A^b3G^b", "NN^a", "E^b"))
+
+  expect_identical(
+    as.character(parsed),
+    c(
+      "Galf(b1-3)Glcf(b1-",
+      "Neuf5Ac(a2-",
+      "Fruf(b2-"
+    )
+  )
+})
+
 test_that("Linear Code: unknown linkages", {
   expect_equal(as.character(parse_linear_code("Ab?Gb")), "Gal(b1-?)Glc(b1-")
   expect_equal(as.character(parse_linear_code("A?3Gb")), "Gal(?1-3)Glc(b1-")

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -75,3 +75,15 @@ test_that("LINUCS supports on_failure handling", {
     c(valid = "Hex(?1-", invalid = NA_character_)
   )
 })
+
+test_that("LINUCS parses every furanose monosaccharide", {
+  furanose <- unname(furanose_monosaccharide_map())
+  mono_map <- linucs_mono_stem_map()
+  source_names <- names(mono_map)[match(furanose, mono_map)]
+  input <- paste0("[][b-", source_names, "]{}")
+
+  parsed <- parse_linucs(input)
+  graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
+
+  expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
+})

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -87,3 +87,7 @@ test_that("LINUCS parses every furanose monosaccharide", {
 
   expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
 })
+
+test_that("LINUCS rejects malformed Api furanose aliases", {
+  expect_error(parse_linucs("[][b-D-Afif]{}"), "Can't parse")
+})

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -209,7 +209,7 @@ test_that("parse_residue works for each monosaccharide without substituents", {
   )
   expect_equal(
     parse_residue("a212h-1x_1-4"),
-    c(mono = "Xyl", anomer = "?1", sub = "")
+    c(mono = "Xylf", anomer = "?1", sub = "")
   )
   expect_equal(
     parse_residue("a222h-1a_1-5"),
@@ -706,14 +706,18 @@ test_that("parse_residue handles generic nonulosonic acids", {
 })
 
 
-test_that("parse_residue normalizes supported 1-4 ring closures", {
+test_that("parse_residue preserves supported furanose ring closures", {
   expect_equal(
     parse_residue("a2112h-1a_1-4"),
-    c(mono = "Gal", anomer = "a1", sub = "")
+    c(mono = "Galf", anomer = "a1", sub = "")
   )
   expect_equal(
     parse_residue("a2112h-1x_1-4_2*NCC/3=O"),
-    c(mono = "GalNAc", anomer = "?1", sub = "")
+    c(mono = "GalfNAc", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("Aad21122h-2a_2-5_5*NCC/3=O"),
+    c(mono = "Neuf5Ac", anomer = "a2", sub = "")
   )
   expect_equal(
     parse_residue("axxxxh-1x_1-4"),
@@ -727,7 +731,7 @@ test_that("parse_residue normalizes supported 1-4 ring closures", {
   ))
   expect_identical(
     unname(as.character(result)),
-    "Gal(a1-2)Gal(a1-4)Gal(b1-"
+    "Galf(a1-2)Galf(a1-4)Gal(b1-"
   )
 })
 


### PR DESCRIPTION
## Summary

- Preserve explicit furanose forms across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF parsers.
- Centralize conversion between ringless and furanose monosaccharide names.
- Parse generic GlycoCT pentose ring descriptors as `Pen`.
- Add parser-specific and automatic-dispatch regression coverage.

## Verification

```r
parse_glycoct("RES\n1b:b-dgal-HEX-1:4")
# Galf(b1-

parse_wurcs("WURCS=2.0/1,1,0/[a2112h-1a_1-4]/1/")
# Galf(a1-
```

- Audited 572 paired furanose GlycoCT/WURCS records and 30 explicit GlyCAM records from `docs/`.
- All 161 available IUPAC-condensed references matched both GlycoCT and WURCS output.
- Full test suite passes.
- `R CMD check`: 0 errors, 0 warnings, 1 environment clock-verification NOTE.
