### PR TITLE
Fix furanose tests for expanding glyrepr vocabulary

### DIFF
--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -180,9 +180,12 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
   )
 })
 
-test_that("GlyCAM IUPAC parses every furanose monosaccharide", {
-  furanose <- unname(furanose_monosaccharide_map())
+test_that("GlyCAM IUPAC parses every mapped furanose monosaccharide", {
   mono_map <- glycam_iupac_mono_map()
+  furanose <- intersect(
+    unname(furanose_monosaccharide_map()),
+    unname(mono_map)
+  )
   source_names <- names(mono_map)[match(furanose, mono_map)]
   anomer_pos <- glyrepr::get_anomer_pos(furanose)
   input <- paste0(source_names, "?", anomer_pos, "-OH")

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -76,9 +76,12 @@ test_that("LINUCS supports on_failure handling", {
   )
 })
 
-test_that("LINUCS parses every furanose monosaccharide", {
-  furanose <- unname(furanose_monosaccharide_map())
+test_that("LINUCS parses every mapped furanose monosaccharide", {
   mono_map <- linucs_mono_stem_map()
+  furanose <- intersect(
+    unname(furanose_monosaccharide_map()),
+    unname(mono_map)
+  )
   source_names <- names(mono_map)[match(furanose, mono_map)]
   input <- paste0("[][b-", source_names, "]{}")
 


### PR DESCRIPTION
## Summary

- Scope exhaustive GlyCAM and LINUCS furanose tests to monosaccharides represented by each parser's source map.
- Prevent newly added `glyrepr` monosaccharides without source aliases from generating synthetic `NA` parser inputs.

## Root cause

PR #41 CI used `glyrepr@f5dfed9`. The post-merge `main` workflows installed `glyrepr@8f3bc32`, which added unusual D/L configurations and expanded the concrete furanose vocabulary. The tests assumed every concrete `glyrepr` furanose must have a GlyCAM or LINUCS source alias, so unmatched names became `NA?1-OH`, `NA?2-OH`, and `[][b-NA]{}`.

## Verification

- Full test suite passes with `glyrepr@8f3bc32` loaded from current `glyrepr` main.
- Isolated `R CMD check` with `glyrepr@8f3bc32`: 0 errors, 0 warnings, 1 environment clock-verification NOTE.

Fixes the failures in [R-CMD-check run 31603863695](https://github.com/glycoverse/glyparse/actions/runs/31603863695) and [test-coverage run 31603863534](https://github.com/glycoverse/glyparse/actions/runs/31603863534).
