### PR TITLE
feat: support unusual monosaccharide configurations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyparse (development version)
 
+* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `DFuc`, `LGul`, and `DFucf`, while unprefixed names retain their natural configurations.
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `DFuc`, `LGul`, and `DFucf`, while unprefixed names retain their natural configurations.
+* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `DFuc`, `LGul`, and `DFucf`, while unprefixed names retain their natural configurations. (#43)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)

--- a/R/furanose.R
+++ b/R/furanose.R
@@ -1,3 +1,64 @@
+#' Map natural monosaccharide names to their unusual configurations
+#'
+#' @return A named character vector from natural to unusual configurations.
+#' @noRd
+unusual_configuration_monosaccharide_map <- local({
+  map <- NULL
+
+  function() {
+    if (is.null(map)) {
+      monos <- glyrepr::available_monosaccharides("concrete")
+      unusual <- monos[
+        stringr::str_detect(monos, "^[DL]") &
+          stringr::str_sub(monos, 2) %in% monos
+      ]
+      map <<- rlang::set_names(unusual, stringr::str_sub(unusual, 2))
+    }
+    map
+  }
+})
+
+
+#' Apply an explicit monosaccharide configuration
+#'
+#' @param mono A glyrepr monosaccharide name in its natural configuration.
+#' @param configuration An explicit `D`, `L`, or unknown configuration.
+#'
+#' @return A glyrepr monosaccharide name.
+#' @noRd
+apply_monosaccharide_configuration <- function(mono, configuration) {
+  map <- unusual_configuration_monosaccharide_map()
+  natural <- names(map)[order(nchar(names(map)), decreasing = TRUE)]
+
+  purrr::map2_chr(mono, configuration, function(value, config) {
+    matched <- natural[stringr::str_starts(value, stringr::fixed(natural))]
+    if (length(matched) == 0) {
+      return(value)
+    }
+
+    matched <- matched[[1]]
+    unusual <- unname(map[[matched]])
+    if (is.na(config) || stringr::str_sub(unusual, 1, 1) != config) {
+      return(value)
+    }
+
+    suffix <- stringr::str_sub(value, nchar(matched) + 1)
+    paste0(unusual, suffix)
+  })
+}
+
+
+#' Swap explicit D and L configuration markers
+#'
+#' @param x A character vector containing single-letter configurations.
+#'
+#' @return A character vector with `D` and `L` exchanged.
+#' @noRd
+invert_configuration <- function(x) {
+  chartr("DLdl", "LDld", x)
+}
+
+
 #' Map ringless concrete monosaccharides to their furanose forms
 #'
 #' @return A named character vector.

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -182,7 +182,7 @@ convert_glycam_iupac_mono <- function(mono) {
 #' @return A named character vector mapping GlyCAM labels to glyrepr labels.
 #' @noRd
 glycam_iupac_mono_map <- function() {
-  add_furanose_monosaccharide_mappings(c(
+  map <- c(
     Hexp = "Hex",
     DFucp = "Fuc",
     DGalp = "Gal",
@@ -264,7 +264,27 @@ glycam_iupac_mono_map <- function() {
     DTagp = "Tag",
     LSorp = "Sor",
     DPsip = "Psi"
-  ))
+  )
+
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  configurable <- stringr::str_detect(names(map), "^[DL]") &
+    unname(map) %in% names(unusual_map)
+  configurations <- stringr::str_sub(names(map)[configurable], 1, 1)
+  natural_monos <- unname(map[configurable])
+  map[configurable] <- apply_monosaccharide_configuration(
+    natural_monos,
+    configurations
+  )
+  unusual_sources <- names(map)[configurable]
+  stringr::str_sub(unusual_sources, 1, 1) <- invert_configuration(
+    configurations
+  )
+  map[unusual_sources] <- apply_monosaccharide_configuration(
+    natural_monos,
+    invert_configuration(configurations)
+  )
+
+  add_furanose_monosaccharide_mappings(map)
 }
 
 

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -820,6 +820,36 @@ format_glycoct_reducing_anomer <- function(reducing_end) {
   paste0(anomer_config, anomer_pos)
 }
 
+
+#' Add unusual configurations to GlycoCT monosaccharide mappings
+#'
+#' @param mappings Named GlycoCT monosaccharide mappings.
+#'
+#' @return The mappings with configuration-inverted counterparts.
+#' @noRd
+add_unusual_glycoct_mappings <- function(mappings) {
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  natural <- intersect(names(mappings), names(unusual_map))
+  unusual <- mappings[natural]
+
+  unusual <- purrr::map(unusual, function(mapping) {
+    mapping$res <- stringr::str_replace_all(
+      mapping$res,
+      "(?<=-)[dl](?=[a-z])",
+      \(configuration) invert_configuration(configuration)
+    )
+    mapping
+  })
+  names(unusual) <- unname(unusual_map[natural])
+  duplicates <- purrr::map_lgl(
+    unusual,
+    \(mapping) any(purrr::map_lgl(mappings, identical, mapping))
+  )
+  unusual <- unusual[!duplicates]
+
+  c(mappings, unusual)
+}
+
 load_mono_mappings <- function() {
   # Hardcoded GLYCOCT_MAP to avoid external file dependency
   GLYCOCT_MAP <- list(
@@ -1129,7 +1159,7 @@ load_mono_mappings <- function() {
     )
   )
 
-  return(GLYCOCT_MAP)
+  add_unusual_glycoct_mappings(GLYCOCT_MAP)
 }
 
 #' Load GlycoCT alditol monosaccharide mappings
@@ -1354,7 +1384,7 @@ load_alditol_mono_mappings <- function() {
     )
   )
 
-  return(GLYCOCT_ALDITOL_MAP)
+  add_unusual_glycoct_mappings(GLYCOCT_ALDITOL_MAP)
 }
 
 compile_glycoct_mapping <- function(name, mapping) {

--- a/R/parse-iupac-extended.R
+++ b/R/parse-iupac-extended.R
@@ -138,6 +138,15 @@ convert_token <- function(token) {
   )
   mono <- stringr::str_extract(token, RESIDUE_PATTERN, group = 2)
   new_mono <- convert_mono(mono)
+  configuration <- stringr::str_extract(
+    token,
+    "-([DL\\?])-",
+    group = 1
+  )
+  new_mono <- apply_monosaccharide_configuration(
+    new_mono,
+    configuration
+  )
   pos1 <- stringr::str_extract(token, RESIDUE_PATTERN, group = 3)
   # pos2 might be missing for the core monosaccharide
   # e.g. GlcNAc(b1-6)]GalNAc(a1-

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -298,7 +298,7 @@ match_linucs_mono_stem <- function(x) {
 #' @return A named character vector.
 #' @noRd
 linucs_mono_stem_map <- function() {
-  add_furanose_monosaccharide_mappings(c(
+  map <- c(
     `6-deoxy-HexpNAc` = "dHexNAc",
     `6-deoxy-HexNAc` = "dHexNAc",
     HexpNAc = "HexNAc",
@@ -358,7 +358,7 @@ linucs_mono_stem_map <- function() {
     `D-QuipNAc` = "QuiNAc",
     `L-RhapNAc` = "RhaNAc",
     `L-Fucp` = "Fuc",
-    `D-Fucp` = "dHex",
+    `D-Fucp` = "Fuc",
     `D-Quip` = "Qui",
     `L-Rhap` = "Rha",
     `D-Olip` = "Oli",
@@ -400,7 +400,32 @@ linucs_mono_stem_map <- function() {
     `D-Tagp` = "Tag",
     `L-Sorp` = "Sor",
     `D-Psip` = "Psi"
-  ))
+  )
+
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  configurable <- unname(map) %in%
+    names(unusual_map) &
+    stringr::str_detect(names(map), "(^|6-deoxy-)[DL]-")
+  configurations <- stringr::str_extract(
+    names(map)[configurable],
+    "[DL](?=-)"
+  )
+  natural_monos <- unname(map[configurable])
+  map[configurable] <- apply_monosaccharide_configuration(
+    natural_monos,
+    configurations
+  )
+  unusual_sources <- stringr::str_replace(
+    names(map)[configurable],
+    "[DL](?=-)",
+    \(configuration) invert_configuration(configuration)
+  )
+  map[unusual_sources] <- apply_monosaccharide_configuration(
+    natural_monos,
+    invert_configuration(configurations)
+  )
+
+  add_furanose_monosaccharide_mappings(map)
 }
 
 

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -494,7 +494,9 @@ linucs_n_sulfate_monos <- function() {
     "TalN",
     "IdoN"
   )
-  c(monos, as_furanose_monosaccharide(monos))
+  unusual <- unname(unusual_configuration_monosaccharide_map()[monos])
+  monos <- c(monos, unusual[!is.na(unusual)])
+  unique(c(monos, as_furanose_monosaccharide(monos)))
 }
 
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -434,6 +434,51 @@ WURCS_ALDITOL_MONO_REGEX <- c(
 )
 
 
+#' Invert the stereochemical backbone in a WURCS pattern
+#'
+#' @param pattern A WURCS monosaccharide regular expression.
+#'
+#' @return A pattern for the opposite absolute configuration.
+#' @noRd
+invert_wurcs_pattern_configuration <- function(pattern) {
+  backbone <- stringr::str_extract(pattern, "(?<=\\^)[[:alnum:]]+")
+  inverted <- chartr("12", "21", backbone)
+  stringr::str_replace(pattern, stringr::fixed(backbone), inverted)
+}
+
+
+#' Add unusual configurations to WURCS monosaccharide patterns
+#'
+#' @param patterns Named WURCS monosaccharide regular expressions.
+#'
+#' @return Patterns including configuration-inverted counterparts.
+#' @noRd
+add_unusual_wurcs_patterns <- function(patterns) {
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  configurable <- names(patterns) %in% names(unusual_map)
+  unusual <- purrr::map_chr(
+    patterns[configurable],
+    invert_wurcs_pattern_configuration
+  )
+  names(unusual) <- unname(unusual_map[names(patterns)[configurable]])
+  unusual <- unusual[!unname(unusual) %in% unname(patterns)]
+
+  c(unusual, patterns)
+}
+
+
+WURCS_MONO_REGEX <- add_unusual_wurcs_patterns(WURCS_MONO_REGEX)
+WURCS_UNKNOWN_RING_MONO_REGEX <- add_unusual_wurcs_patterns(
+  WURCS_UNKNOWN_RING_MONO_REGEX
+)
+WURCS_AMBIGUOUS_MONO_REGEX <- add_unusual_wurcs_patterns(
+  WURCS_AMBIGUOUS_MONO_REGEX
+)
+WURCS_ALDITOL_MONO_REGEX <- add_unusual_wurcs_patterns(
+  WURCS_ALDITOL_MONO_REGEX
+)
+
+
 WURCS_SUB_REGEX <- c(
   "Me" = "OC",
   "Ac" = "OCC/3=O",

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -692,19 +692,34 @@ parse_residue_details <- function(residue) {
   # Get substituent(s)
   # For Neu5Ac and Neu5Gc, we need special handling since the 5-position NAc/NGc
   # is part of the monosaccharide itself, not an additional substituent
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  identity_mono <- names(unusual_map)[
+    match(mono, unname(unusual_map))
+  ]
+  if (is.na(identity_mono)) {
+    identity_mono <- mono
+  }
   if (
-    mono %in%
+    identity_mono %in%
       c("Neu5Ac", "Neu5Gc", "Neu") &&
       !is_alditol &&
       stringr::str_starts(matching_residue, "Aad")
   ) {
     # For Neu5Ac/Neu5Gc, remove the base Kdn structure and the characteristic 5-position modification
-    base_kdn_pattern <- "^Aad21122h-2[abx]_2-(?:6|\\?)"
-    if (mono == "Neu5Ac") {
+    backbone <- stringr::str_extract(
+      mono_pattern,
+      "(?<=\\^)[[:alnum:]]+"
+    )
+    base_kdn_pattern <- paste0(
+      "^",
+      backbone,
+      "-2[abx]_2-(?:6|\\?)"
+    )
+    if (identity_mono == "Neu5Ac") {
       # Remove the base Kdn pattern and the 5*NCC/3=O
       sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
-    } else if (mono == "Neu5Gc") {
+    } else if (identity_mono == "Neu5Gc") {
       # Remove the base Kdn pattern and the 5*NCCO/3=O
       sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
@@ -716,15 +731,19 @@ parse_residue_details <- function(residue) {
       )
     }
   } else if (
-    mono %in%
+    identity_mono %in%
       c("Neu5Ac", "Neu5Gc", "Neu") &&
       stringr::str_starts(matching_residue, "AUd")
   ) {
-    base_kdn_pattern <- "^AUd21122h"
+    backbone <- stringr::str_extract(
+      mono_pattern,
+      "(?<=\\^)[[:alnum:]]+"
+    )
+    base_kdn_pattern <- paste0("^", backbone)
     sub_code <- stringr::str_remove(matching_residue, base_kdn_pattern)
-    if (mono == "Neu5Ac") {
+    if (identity_mono == "Neu5Ac") {
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCC/3=O")
-    } else if (mono == "Neu5Gc") {
+    } else if (identity_mono == "Neu5Gc") {
       sub_code <- stringr::str_remove(sub_code, "_5\\*NCCO/3=O")
     } else {
       sub_code <- stringr::str_remove(sub_code, "_5\\*N(?!CC(O)?/3=O)")

--- a/tests/testthat/test-auto-parse.R
+++ b/tests/testthat/test-auto-parse.R
@@ -72,6 +72,17 @@ test_that("auto_parse correctly identifies and parses GlyCAM IUPAC format", {
   expect_equal(as.character(result), as.character(expected))
 })
 
+test_that("auto_parse preserves unusual configurations", {
+  expect_identical(
+    as.character(auto_parse("DFucpa1-OH")),
+    "DFuc(a1-"
+  )
+  expect_identical(
+    as.character(auto_parse("DFuc(a1-")),
+    "DFuc(a1-"
+  )
+})
+
 test_that("auto_parse correctly identifies and parses IUPAC-compact format", {
   input <- "Mana1-3(Mana1-6)Manb1-4GlcNAcb"
   result <- auto_parse(input)

--- a/tests/testthat/test-furanose.R
+++ b/tests/testthat/test-furanose.R
@@ -21,8 +21,10 @@ test_that("furanose aliases replace only pyranose ring markers", {
   glycam_map <- glycam_iupac_mono_map()
   linucs_map <- linucs_mono_stem_map()
 
-  expect_identical(unname(glycam_map[["DApif"]]), "Apif")
-  expect_identical(unname(linucs_map[["D-Apif"]]), "Apif")
+  expect_identical(unname(glycam_map[["DApif"]]), "DApif")
+  expect_identical(unname(glycam_map[["LApif"]]), "Apif")
+  expect_identical(unname(linucs_map[["D-Apif"]]), "DApif")
+  expect_identical(unname(linucs_map[["L-Apif"]]), "Apif")
   expect_false("DAfif" %in% names(glycam_map))
   expect_false("D-Afif" %in% names(linucs_map))
 })

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -29,6 +29,25 @@ test_that("GlyCAM IUPAC parses generic monosaccharides alone", {
   expect_identical(as.character(parsed), c(Hex = "Hex(b1-"))
 })
 
+test_that("GlyCAM IUPAC preserves unusual configurations", {
+  parsed <- parse_glycam_iupac(c(
+    natural_fucose = "LFucpa1-OH",
+    d_fucose = "DFucp[3S]a1-OH",
+    l_gulose = "LGulpb1-OH",
+    d_fucofuranose = "DFucfa1-OH"
+  ))
+
+  expect_identical(
+    as.character(parsed),
+    c(
+      natural_fucose = "Fuc(a1-",
+      d_fucose = "DFuc3S(a1-",
+      l_gulose = "LGul(b1-",
+      d_fucofuranose = "DFucf(a1-"
+    )
+  )
+})
+
 test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
   skip_on_old_win()
 
@@ -153,7 +172,7 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
       Dig = "Dig(b1-",
       Col = "Col(b1-",
       Ara = "Ara(b1-",
-      Lyx = "Lyx(b1-",
+      Lyx = "LLyx(b1-",
       Xyl = "Xyl(b1-",
       Rib = "Rib(b1-",
       Neu5Ac = "Neu5Ac(b2-",
@@ -171,7 +190,7 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
       MurNAc = "MurNAc(b1-",
       MurNGc = "MurNGc(b1-",
       Mur = "Mur(b1-",
-      Api = "Apif(b1-",
+      Api = "DApif(b1-",
       Fru = "Fru(b2-",
       Tag = "Tag(b2-",
       Sor = "Sor(b2-",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -38,6 +38,23 @@ test_that("GlycoCT preserves furanose ring bounds", {
   )
 })
 
+test_that("GlycoCT preserves unusual configurations", {
+  expect_warning(
+    parsed <- parse_glycoct(c(
+      "RES\n1b:a-dgal-HEX-1:5|6:d",
+      "RES\n1b:b-lgul-HEX-1:5",
+      "RES\n1b:x-dido-HEX-1:5|6:a",
+      "RES\n1b:a-dgal-HEX-1:4|6:d",
+      "RES\n1b:o-dgal-HEX-0:0|1:aldi|6:d"
+    )),
+    "regular reducing-end glycans"
+  )
+  expect_identical(
+    as.character(parsed),
+    c("DFuc(a1-", "LGul(b1-", "DIdoA(?1-", "DFucf(a1-", "DFuc(?1-")
+  )
+})
+
 test_that("GlycoCT accepts space-separated records", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-iupac-condensed.R
+++ b/tests/testthat/test-parse-iupac-condensed.R
@@ -5,6 +5,17 @@ test_that("IUPAC-condensed: some O-glycan", {
   expect_snapshot(print(glycan, verbose = TRUE))
 })
 
+test_that("IUPAC-condensed preserves unusual configurations", {
+  parsed <- parse_iupac_condensed(
+    "DFuc3S(a1-2)[LGul(b1-3)]DFucf(?1-"
+  )
+
+  expect_identical(
+    as.character(parsed),
+    "DFuc3S(a1-2)[LGul(b1-3)]DFucf(?1-"
+  )
+})
+
 test_that("IUPAC-condensed can drop generic glycans", {
   input <- c("Hex(??-", "Glc(?1-", "HexNAc(??-")
 

--- a/tests/testthat/test-parse-iupac-extended.R
+++ b/tests/testthat/test-parse-iupac-extended.R
@@ -18,14 +18,42 @@ test_that("monosaccharides are parsed correctly", {
 
 test_that("every furanose monosaccharide is parsed correctly", {
   furanose <- unname(furanose_monosaccharide_map())
-  extended <- names(IUPAC_EXT_TO_CON)[match(furanose, IUPAC_EXT_TO_CON)]
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  unusual_index <- match(furanose, unname(unusual_map))
+  natural <- furanose
+  natural[!is.na(unusual_index)] <- names(unusual_map)[
+    unusual_index[!is.na(unusual_index)]
+  ]
+  unusual <- unname(unusual_map[natural])
+  configuration <- invert_configuration(stringr::str_sub(unusual, 1, 1))
+  configuration[!is.na(unusual_index)] <- stringr::str_sub(
+    furanose[!is.na(unusual_index)],
+    1,
+    1
+  )
+  configuration[is.na(configuration)] <- "?"
+  extended <- names(IUPAC_EXT_TO_CON)[match(natural, IUPAC_EXT_TO_CON)]
   anomer_pos <- glyrepr::get_anomer_pos(furanose)
-  input <- paste0("?-D-", extended, "-(", anomer_pos, "→")
+  input <- paste0("?-", configuration, "-", extended, "-(", anomer_pos, "→")
 
   parsed <- parse_iupac_extended(input)
   graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
 
   expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), furanose)
+})
+
+
+test_that("IUPAC-extended preserves unusual configurations", {
+  parsed <- parse_iupac_extended(c(
+    "α-L-Gulp-(1→",
+    "β-D-Fucp3S-(1→",
+    "?-D-Fucf-(1→"
+  ))
+
+  expect_identical(
+    as.character(parsed),
+    c("LGul(a1-", "DFuc3S(b1-", "DFucf(?1-")
+  )
 })
 
 

--- a/tests/testthat/test-parse-kcf.R
+++ b/tests/testthat/test-parse-kcf.R
@@ -155,6 +155,24 @@ test_that("KCF parses a single monosaccharide", {
   expect_equal(result, "Glc(?1-")
 })
 
+test_that("KCF preserves unusual configurations", {
+  records <- paste0(
+    "ENTRY       test                      Glycan\n",
+    "NODE        1\n",
+    "            1   ",
+    c("LFuc", "DFuc3S", "LGul", "DFucf"),
+    "         0     0\n",
+    "///"
+  )
+
+  parsed <- parse_kcf(records)
+
+  expect_identical(
+    as.character(parsed),
+    c("Fuc(?1-", "DFuc3S(?1-", "LGul(?1-", "DFucf(?1-")
+  )
+})
+
 test_that("KCF parses every furanose monosaccharide label", {
   furanose <- unname(furanose_monosaccharide_map())
   records <- paste0(

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -62,6 +62,20 @@ test_that("LINUCS preserves NA and name semantics", {
   )
 })
 
+test_that("LINUCS preserves unusual configurations", {
+  parsed <- parse_linucs(c(
+    "[][a-L-Fucp]{}",
+    "[][a-D-Fucp3S]{}",
+    "[][b-L-Gulp]{}",
+    "[][?-D-Fucf]{}"
+  ))
+
+  expect_identical(
+    as.character(parsed),
+    c("Fuc(a1-", "DFuc3S(a1-", "LGul(b1-", "DFucf(?1-")
+  )
+})
+
 test_that("LINUCS supports on_failure handling", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -76,6 +76,25 @@ test_that("LINUCS preserves unusual configurations", {
   )
 })
 
+test_that("LINUCS parses N-sulfate suffixes on unusual configurations", {
+  parsed <- parse_linucs(c(
+    "[][L-GulpNS]{}",
+    "[][L-GulfNS]{}",
+    "[][D-IdopNS]{}",
+    "[][D-IdofNS]{}"
+  ))
+
+  expect_identical(
+    as.character(parsed),
+    c(
+      "LGulN2S(?1-",
+      "LGulfN2S(?1-",
+      "DIdoN2S(?1-",
+      "DIdofN2S(?1-"
+    )
+  )
+})
+
 test_that("LINUCS supports on_failure handling", {
   skip_on_old_win()
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -298,6 +298,36 @@ test_that("parse_residue works for each monosaccharide without substituents", {
 })
 
 
+test_that("parse_residue preserves unusual configurations", {
+  residues <- c(
+    DFuc = "a2112m-1a_1-5",
+    DFucf = "a2112m-1a_1-4",
+    LGul = "a1121h-1b_1-5",
+    DIdoA = "a1212A-1x_1-5",
+    LNeu5Ac = "Aad12211h-2a_2-6_5*NCC/3=O",
+    LGul_unknown_ring = "a1121h-1x_1-?",
+    DFuc_ambiguous = "u2112m",
+    DFuc_alditol = "h2112m"
+  )
+
+  parsed <- purrr::map(residues, parse_residue)
+
+  expect_identical(
+    purrr::map_chr(parsed, "mono"),
+    c(
+      DFuc = "DFuc",
+      DFucf = "DFucf",
+      LGul = "LGul",
+      DIdoA = "DIdoA",
+      LNeu5Ac = "LNeu5Ac",
+      LGul_unknown_ring = "LGul",
+      DFuc_ambiguous = "DFuc",
+      DFuc_alditol = "DFuc"
+    )
+  )
+})
+
+
 test_that("parse_residue raises an error with unkown monosaccharide", {
   expect_error(
     parse_residue("axxxxxh-1a_1-5"),
@@ -636,7 +666,7 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
   )
   expect_equal(
     parse_residue("u2112m"),
-    c(mono = "dHex", anomer = "??", sub = "")
+    c(mono = "DFuc", anomer = "??", sub = "")
   )
   expect_equal(
     parse_residue("a2112m-1x_1-5_2*NCC/3=O"),

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -688,6 +688,10 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
     parse_residue("AUd21122h_4*OCC/3=O_5*NCC/3=O"),
     c(mono = "Neu5Ac", anomer = "??", sub = "4Ac")
   )
+  expect_equal(
+    parse_residue("AUd12211h_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "LNeu5Ac", anomer = "??", sub = "4Ac")
+  )
 })
 
 
@@ -770,6 +774,14 @@ test_that("parse_residue handles unknown ring closure", {
   expect_equal(
     parse_residue("Aad21122h-2x_2-?_5*NCC/3=O"),
     c(mono = "Neu5Ac", anomer = "?2", sub = "")
+  )
+  expect_equal(
+    parse_residue("Aad12211h-2a_2-?_4*OCC/3=O_5*NCC/3=O"),
+    c(mono = "LNeu5Ac", anomer = "a2", sub = "4Ac")
+  )
+  expect_equal(
+    parse_residue("Aad12211h-2b_2-?_5*NCCO/3=O"),
+    c(mono = "LNeu5Gc", anomer = "b2", sub = "")
   )
   expect_equal(
     parse_residue("Aad21122h-2a_2-?_4*OCC/3=O_5*NCC/3=O"),


### PR DESCRIPTION
Related to glycoverse/glyrepr#85

## Summary

- preserve unusual monosaccharide configurations such as `DFuc`, `LGul`, `DIdoA`, and `DFucf`
- support explicit configurations across GlyCAM IUPAC, IUPAC-extended, LINUCS, KCF, GlycoCT, WURCS, and automatic parsing
- retain unprefixed canonical names for natural configurations
- cover substituents, furanose forms, ambiguous residues, unknown rings, and alditols

## Verification

- `devtools::test()`
- `devtools::check(error_on = "warning")` — 0 errors, 0 warnings, one system-clock NOTE
- all 129 documentation records containing unusual GlyCAM configurations produced identical GlyCAM, GlycoCT, and WURCS output
- all 351 comparable unusual-configuration GlycoCT/WURCS records produced identical output
- `git diff --check`