### PR TITLE
fix: align unusual configurations and residue coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43)
+* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43, #44)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `DFuc`, `LGul`, and `DFucf`, while unprefixed names retain their natural configurations. (#43)
+* Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)
 * `parse_glycoct()` now supports floating glycan substructures represented by `UND` sections, uses implicit floating parts when every main-tree node is a candidate parent, and excludes explicit candidates whose acceptor positions are already occupied. (#40)

--- a/R/furanose.R
+++ b/R/furanose.R
@@ -9,10 +9,10 @@ unusual_configuration_monosaccharide_map <- local({
     if (is.null(map)) {
       monos <- glyrepr::available_monosaccharides("concrete")
       unusual <- monos[
-        stringr::str_detect(monos, "^[DL]") &
-          stringr::str_sub(monos, 2) %in% monos
+        stringr::str_detect(monos, "^[DL]-") &
+          stringr::str_sub(monos, 3) %in% monos
       ]
-      map <<- rlang::set_names(unusual, stringr::str_sub(unusual, 2))
+      map <<- rlang::set_names(unusual, stringr::str_sub(unusual, 3))
     }
     map
   }

--- a/R/parse-kcf.R
+++ b/R/parse-kcf.R
@@ -398,13 +398,19 @@ make_kcf_igraph <- function(vertices, glycan_edges) {
 #' @noRd
 parse_kcf_monosaccharide_label <- function(label) {
   candidates <- label
-  if (stringr::str_detect(label, "^[DL].+")) {
+  configurations <- NA_character_
+  if (stringr::str_detect(label, "^[DL](?!-).+")) {
     candidates <- c(candidates, stringr::str_sub(label, 2))
+    configurations <- c(configurations, stringr::str_sub(label, 1, 1))
   }
 
-  for (candidate in candidates) {
-    parsed <- parse_kcf_monosaccharide_candidate(candidate)
+  for (index in seq_along(candidates)) {
+    parsed <- parse_kcf_monosaccharide_candidate(candidates[[index]])
     if (!is.null(parsed)) {
+      parsed$mono <- apply_monosaccharide_configuration(
+        parsed$mono,
+        configurations[[index]]
+      )
       return(parsed)
     }
   }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -81,6 +81,9 @@ WURCS_MONO_REGEX <- c(
   # For GlcNAc, we have to differentiate it from MurNAc.
   "GlcNAc" = "^a2122h-1[abx]_1-5_2\\*NCC/3=O(?!_3\\*OC\\^RCO/4=O/3C)",
   "GalNAc" = "^a2112h-1[abx]_1-5_2\\*NCC/3=O",
+  # GlycanFormatConverter also recognizes this relative-configuration
+  # descriptor as ManNAc.
+  "ManNAc" = "^a5122h-1[abx]_1-5_2\\*NCC/3=O",
   "ManNAc" = "^a1122h-1[abx]_1-5_2\\*NCC/3=O",
   "GulNAc" = "^a2212h-1[abx]_1-5_2\\*NCC/3=O",
   "AltNAc" = "^a2111h-1[abx]_1-5_2\\*NCC/3=O",
@@ -461,7 +464,14 @@ add_unusual_wurcs_patterns <- function(patterns) {
     invert_wurcs_pattern_configuration
   )
   names(unusual) <- unname(unusual_map[names(patterns)[configurable]])
-  unusual <- unusual[!unname(unusual) %in% unname(patterns)]
+
+  # Preserve a configuration-specific pattern when it collides with a generic
+  # fallback (for example D-FucNAc and dHexNAc). Indistinguishable concrete
+  # aliases keep the existing canonical monosaccharide name.
+  duplicate_index <- match(unname(unusual), unname(patterns))
+  duplicate_names <- names(patterns)[duplicate_index]
+  generic <- glyrepr::available_monosaccharides("generic")
+  unusual <- unusual[is.na(duplicate_names) | duplicate_names %in% generic]
 
   c(unusual, patterns)
 }

--- a/tests/testthat/test-auto-parse.R
+++ b/tests/testthat/test-auto-parse.R
@@ -75,11 +75,11 @@ test_that("auto_parse correctly identifies and parses GlyCAM IUPAC format", {
 test_that("auto_parse preserves unusual configurations", {
   expect_identical(
     as.character(auto_parse("DFucpa1-OH")),
-    "DFuc(a1-"
+    "D-Fuc(a1-"
   )
   expect_identical(
-    as.character(auto_parse("DFuc(a1-")),
-    "DFuc(a1-"
+    as.character(auto_parse("D-Fuc(a1-")),
+    "D-Fuc(a1-"
   )
 })
 

--- a/tests/testthat/test-furanose.R
+++ b/tests/testthat/test-furanose.R
@@ -7,6 +7,40 @@ test_that("furanose helpers cover every concrete monosaccharide", {
   expect_identical(as_ringless_monosaccharide(unname(map)), names(map))
 })
 
+test_that("unusual configuration helpers cover every supported pair", {
+  map <- unusual_configuration_monosaccharide_map()
+  concrete <- glyrepr::available_monosaccharides("concrete")
+  unusual <- concrete[stringr::str_detect(concrete, "^[DL]-")]
+  expected <- unusual[stringr::str_sub(unusual, 3) %in% concrete]
+  expected <- rlang::set_names(expected, stringr::str_sub(expected, 3))
+
+  expect_identical(map, expected)
+  expect_identical(
+    apply_monosaccharide_configuration(
+      names(map),
+      stringr::str_sub(unname(map), 1, 1)
+    ),
+    unname(map)
+  )
+})
+
+test_that("IUPAC-condensed parses every unusual configuration", {
+  unusual <- unname(unusual_configuration_monosaccharide_map())
+  anomer_pos <- glyrepr::get_anomer_pos(unusual)
+  input <- paste0(unusual, "(?", anomer_pos, "-")
+
+  parsed <- parse_iupac_condensed(input)
+
+  expect_identical(as.character(parsed), input)
+})
+
+test_that("IUPAC-condensed rejects legacy unhyphenated configurations", {
+  expect_error(
+    parse_iupac_condensed(c("DFuc(?1-", "LGul(?1-", "DApif(?1-")),
+    "Can't parse"
+  )
+})
+
 test_that("IUPAC-condensed parses every furanose monosaccharide", {
   furanose <- unname(furanose_monosaccharide_map())
   anomer_pos <- glyrepr::get_anomer_pos(furanose)
@@ -21,9 +55,9 @@ test_that("furanose aliases replace only pyranose ring markers", {
   glycam_map <- glycam_iupac_mono_map()
   linucs_map <- linucs_mono_stem_map()
 
-  expect_identical(unname(glycam_map[["DApif"]]), "DApif")
+  expect_identical(unname(glycam_map[["DApif"]]), "D-Apif")
   expect_identical(unname(glycam_map[["LApif"]]), "Apif")
-  expect_identical(unname(linucs_map[["D-Apif"]]), "DApif")
+  expect_identical(unname(linucs_map[["D-Apif"]]), "D-Apif")
   expect_identical(unname(linucs_map[["L-Apif"]]), "Apif")
   expect_false("DAfif" %in% names(glycam_map))
   expect_false("D-Afif" %in% names(linucs_map))

--- a/tests/testthat/test-parse-glycam-iupac.R
+++ b/tests/testthat/test-parse-glycam-iupac.R
@@ -41,9 +41,9 @@ test_that("GlyCAM IUPAC preserves unusual configurations", {
     as.character(parsed),
     c(
       natural_fucose = "Fuc(a1-",
-      d_fucose = "DFuc3S(a1-",
-      l_gulose = "LGul(b1-",
-      d_fucofuranose = "DFucf(a1-"
+      d_fucose = "D-Fuc3S(a1-",
+      l_gulose = "L-Gul(b1-",
+      d_fucofuranose = "D-Fucf(a1-"
     )
   )
 })
@@ -172,7 +172,7 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
       Dig = "Dig(b1-",
       Col = "Col(b1-",
       Ara = "Ara(b1-",
-      Lyx = "LLyx(b1-",
+      Lyx = "L-Lyx(b1-",
       Xyl = "Xyl(b1-",
       Rib = "Rib(b1-",
       Neu5Ac = "Neu5Ac(b2-",
@@ -190,7 +190,7 @@ test_that("GlyCAM IUPAC parses checklist monosaccharide names", {
       MurNAc = "MurNAc(b1-",
       MurNGc = "MurNGc(b1-",
       Mur = "Mur(b1-",
-      Api = "DApif(b1-",
+      Api = "D-Apif(b1-",
       Fru = "Fru(b2-",
       Tag = "Tag(b2-",
       Sor = "Sor(b2-",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -51,7 +51,7 @@ test_that("GlycoCT preserves unusual configurations", {
   )
   expect_identical(
     as.character(parsed),
-    c("DFuc(a1-", "LGul(b1-", "DIdoA(?1-", "DFucf(a1-", "DFuc(?1-")
+    c("D-Fuc(a1-", "L-Gul(b1-", "D-IdoA(?1-", "D-Fucf(a1-", "D-Fuc(?1-")
   )
 })
 
@@ -588,6 +588,70 @@ test_that("all monosaccharides can be parsed", {
     mapping <- mappings[[mono_name]]
     glycoct <- create_glycoct_from_mapping(mapping)
     expect_mono_equal(parse_glycoct(glycoct), mono_name)
+  }
+})
+
+test_that("GlycoCT mappings cover every distinguishable unusual configuration", {
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  concrete <- glyrepr::available_monosaccharides("concrete")
+  mappings <- load_mono_mappings()
+  natural <- intersect(names(mappings), names(unusual_map))
+
+  for (mono in natural) {
+    unusual_name <- unname(unusual_map[[mono]])
+    unusual_mapping <- mappings[[mono]]
+    unusual_mapping$res <- stringr::str_replace_all(
+      unusual_mapping$res,
+      "(?<=-)[dl](?=[a-z])",
+      \(configuration) invert_configuration(configuration)
+    )
+    matching_names <- names(mappings)[purrr::map_lgl(
+      mappings,
+      identical,
+      unusual_mapping
+    )]
+
+    expect_true(
+      unusual_name %in% matching_names || any(matching_names %in% concrete),
+      info = paste("missing unusual GlycoCT mapping for", unusual_name)
+    )
+  }
+})
+
+test_that("GlycoCT parses every representable unusual furanose", {
+  unusual <- unname(unusual_configuration_monosaccharide_map())
+  furanose_map <- furanose_monosaccharide_map()
+  furanose <- intersect(unusual, unname(furanose_map))
+  ringless <- names(furanose_map)[match(furanose, unname(furanose_map))]
+  mappings <- load_mono_mappings()
+  represented <- ringless %in% names(mappings)
+  furanose <- furanose[represented]
+  ringless <- ringless[represented]
+
+  for (index in seq_along(furanose)) {
+    mapping <- mappings[[ringless[[index]]]]
+    mapping$res <- stringr::str_replace_all(
+      mapping$res,
+      c("-1:5" = "-1:4", "-2:6" = "-2:5")
+    )
+    glycoct <- paste(
+      c(
+        "RES",
+        mapping$res,
+        if (length(mapping$lin)) c("LIN", mapping$lin)
+      ),
+      collapse = "\n"
+    )
+    graph <- glyrepr::get_structure_graphs(
+      parse_glycoct(glycoct),
+      return_list = FALSE
+    )
+
+    expect_identical(
+      igraph::V(graph)$mono,
+      furanose[[index]],
+      info = paste("failed to preserve unusual furanose", furanose[[index]])
+    )
   }
 })
 

--- a/tests/testthat/test-parse-iupac-condensed.R
+++ b/tests/testthat/test-parse-iupac-condensed.R
@@ -7,12 +7,12 @@ test_that("IUPAC-condensed: some O-glycan", {
 
 test_that("IUPAC-condensed preserves unusual configurations", {
   parsed <- parse_iupac_condensed(
-    "DFuc3S(a1-2)[LGul(b1-3)]DFucf(?1-"
+    "D-Fuc3S(a1-2)[L-Gul(b1-3)]D-Fucf(?1-"
   )
 
   expect_identical(
     as.character(parsed),
-    "DFuc3S(a1-2)[LGul(b1-3)]DFucf(?1-"
+    "D-Fuc3S(a1-2)[L-Gul(b1-3)]D-Fucf(?1-"
   )
 })
 

--- a/tests/testthat/test-parse-iupac-extended.R
+++ b/tests/testthat/test-parse-iupac-extended.R
@@ -52,7 +52,7 @@ test_that("IUPAC-extended preserves unusual configurations", {
 
   expect_identical(
     as.character(parsed),
-    c("LGul(a1-", "DFuc3S(b1-", "DFucf(?1-")
+    c("L-Gul(a1-", "D-Fuc3S(b1-", "D-Fucf(?1-")
   )
 })
 

--- a/tests/testthat/test-parse-kcf.R
+++ b/tests/testthat/test-parse-kcf.R
@@ -169,8 +169,26 @@ test_that("KCF preserves unusual configurations", {
 
   expect_identical(
     as.character(parsed),
-    c("Fuc(?1-", "DFuc3S(?1-", "LGul(?1-", "DFucf(?1-")
+    c("Fuc(?1-", "D-Fuc3S(?1-", "L-Gul(?1-", "D-Fucf(?1-")
   )
+})
+
+test_that("KCF parses every unusual configuration label", {
+  unusual <- unname(unusual_configuration_monosaccharide_map())
+  labels <- stringr::str_remove(unusual, stringr::fixed("-"))
+  records <- paste0(
+    "ENTRY       test                      Glycan\n",
+    "NODE        1\n",
+    "            1   ",
+    labels,
+    "         0     0\n",
+    "///"
+  )
+
+  parsed <- parse_kcf(records)
+  graphs <- glyrepr::get_structure_graphs(parsed, return_list = TRUE)
+
+  expect_identical(purrr::map_chr(graphs, ~ igraph::V(.x)$mono), unusual)
 })
 
 test_that("KCF parses every furanose monosaccharide label", {

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -72,7 +72,7 @@ test_that("LINUCS preserves unusual configurations", {
 
   expect_identical(
     as.character(parsed),
-    c("Fuc(a1-", "DFuc3S(a1-", "LGul(b1-", "DFucf(?1-")
+    c("Fuc(a1-", "D-Fuc3S(a1-", "L-Gul(b1-", "D-Fucf(?1-")
   )
 })
 
@@ -87,10 +87,10 @@ test_that("LINUCS parses N-sulfate suffixes on unusual configurations", {
   expect_identical(
     as.character(parsed),
     c(
-      "LGulN2S(?1-",
-      "LGulfN2S(?1-",
-      "DIdoN2S(?1-",
-      "DIdofN2S(?1-"
+      "L-GulN2S(?1-",
+      "L-GulfN2S(?1-",
+      "D-IdoN2S(?1-",
+      "D-IdofN2S(?1-"
     )
   )
 })

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -315,15 +315,78 @@ test_that("parse_residue preserves unusual configurations", {
   expect_identical(
     purrr::map_chr(parsed, "mono"),
     c(
-      DFuc = "DFuc",
-      DFucf = "DFucf",
-      LGul = "LGul",
-      DIdoA = "DIdoA",
-      LNeu5Ac = "LNeu5Ac",
-      LGul_unknown_ring = "LGul",
-      DFuc_ambiguous = "DFuc",
-      DFuc_alditol = "DFuc"
+      DFuc = "D-Fuc",
+      DFucf = "D-Fucf",
+      LGul = "L-Gul",
+      DIdoA = "D-IdoA",
+      LNeu5Ac = "L-Neu5Ac",
+      LGul_unknown_ring = "L-Gul",
+      DFuc_ambiguous = "D-Fuc",
+      DFuc_alditol = "D-Fuc"
     )
+  )
+})
+
+test_that("WURCS patterns cover every distinguishable unusual configuration", {
+  unusual_map <- unusual_configuration_monosaccharide_map()
+  concrete <- glyrepr::available_monosaccharides("concrete")
+  pattern_sets <- list(
+    WURCS_MONO_REGEX,
+    WURCS_UNKNOWN_RING_MONO_REGEX,
+    WURCS_AMBIGUOUS_MONO_REGEX,
+    WURCS_ALDITOL_MONO_REGEX
+  )
+
+  for (patterns in pattern_sets) {
+    natural_indices <- which(names(patterns) %in% names(unusual_map))
+    for (index in natural_indices) {
+      unusual_name <- unname(unusual_map[[names(patterns)[[index]]]])
+      unusual_pattern <- invert_wurcs_pattern_configuration(patterns[[index]])
+      matching_names <- names(patterns)[unname(patterns) == unusual_pattern]
+
+      expect_true(
+        unusual_name %in% matching_names || any(matching_names %in% concrete),
+        info = paste("missing unusual WURCS pattern for", unusual_name)
+      )
+    }
+  }
+})
+
+test_that("parse_residue recognizes GlycanFormatConverter alternate codes", {
+  residues <- c(
+    LGal_a = "a1221h-1a_1-5",
+    LGal_b = "a1221h-1b_1-5",
+    LGal_x = "a1221h-1x_1-5",
+    LGal_ambiguous = "u1221h",
+    LGul_a = "a1121h-1a_1-5",
+    LGul_x = "a1121h-1x_1-5",
+    LGul_ambiguous = "u1121h",
+    ManNAc_relative = "a5122h-1b_1-5_2*NCC/3=O"
+  )
+
+  expect_identical(
+    purrr::map_chr(residues, ~ parse_residue(.x)[["mono"]]),
+    c(
+      LGal_a = "L-Gal",
+      LGal_b = "L-Gal",
+      LGal_x = "L-Gal",
+      LGal_ambiguous = "L-Gal",
+      LGul_a = "L-Gul",
+      LGul_x = "L-Gul",
+      LGul_ambiguous = "L-Gul",
+      ManNAc_relative = "ManNAc"
+    )
+  )
+})
+
+test_that("specific unusual WURCS patterns take priority over generic fallbacks", {
+  expect_identical(
+    parse_residue("a2112m-1x_1-5_2*NCC/3=O")[["mono"]],
+    "D-FucNAc"
+  )
+  expect_identical(
+    parse_residue("a2112m-1x_1-4_2*NCC/3=O")[["mono"]],
+    "D-FucfNAc"
   )
 })
 
@@ -666,11 +729,11 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
   )
   expect_equal(
     parse_residue("u2112m"),
-    c(mono = "DFuc", anomer = "??", sub = "")
+    c(mono = "D-Fuc", anomer = "??", sub = "")
   )
   expect_equal(
     parse_residue("a2112m-1x_1-5_2*NCC/3=O"),
-    c(mono = "dHexNAc", anomer = "?1", sub = "")
+    c(mono = "D-FucNAc", anomer = "?1", sub = "")
   )
   expect_equal(
     parse_residue("a4334m-1x_1-?"),
@@ -690,7 +753,7 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
   )
   expect_equal(
     parse_residue("AUd12211h_4*OCC/3=O_5*NCC/3=O"),
-    c(mono = "LNeu5Ac", anomer = "??", sub = "4Ac")
+    c(mono = "L-Neu5Ac", anomer = "??", sub = "4Ac")
   )
 })
 
@@ -777,11 +840,11 @@ test_that("parse_residue handles unknown ring closure", {
   )
   expect_equal(
     parse_residue("Aad12211h-2a_2-?_4*OCC/3=O_5*NCC/3=O"),
-    c(mono = "LNeu5Ac", anomer = "a2", sub = "4Ac")
+    c(mono = "L-Neu5Ac", anomer = "a2", sub = "4Ac")
   )
   expect_equal(
     parse_residue("Aad12211h-2b_2-?_5*NCCO/3=O"),
-    c(mono = "LNeu5Gc", anomer = "b2", sub = "")
+    c(mono = "L-Neu5Gc", anomer = "b2", sub = "")
   )
   expect_equal(
     parse_residue("Aad21122h-2a_2-?_4*OCC/3=O_5*NCC/3=O"),


### PR DESCRIPTION
## Summary
- adopt glyrepr's hyphenated unusual-configuration names such as `D-Fuc` and `L-Gul`
- derive unusual configurations from the complete glyrepr monosaccharide vocabulary
- add missed L-Gal, L-Gul, and ManNAc WURCS residue codes
- prioritize specific `D-FucNAc` patterns over generic `dHexNAc` fallbacks
- add exhaustive WURCS, GlycoCT, KCF, and IUPAC regression coverage

## Verification
- `devtools::test()`: 1,618 expectations passed
- GlycanFormatConverter audit: 0 WURCS and 0 GlycoCT mismatches among 209 representable conversions
- `R CMD check --no-manual --no-vignettes`: package code, examples, and tests passed