### PR TITLE
Support floating substituents in GlycoCT and WURCS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents.
+* `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents. (#45)
 * Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43, #44)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyparse (development version)
 
+* `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents.
 * Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43, #44)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)
 * `auto_parse()` and all format-specific parsers gain `drop_generic` to replace generic glycans with `NA` when generic and concrete glycans coexist, with a message reporting the number dropped. (#39)

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -721,7 +721,7 @@ build_glycoct_floating_graph <- function(
           position,
           glycoct_substituent_abbreviation(substituent)
         )
-        parents <- normalize_floating_substituent_parents(
+        domain <- normalize_floating_substituent_parents(
           parents,
           main_vertices,
           substituent,
@@ -730,8 +730,8 @@ build_glycoct_floating_graph <- function(
         )
 
         list(
-          substituent = substituent,
-          parents = as.integer(parents)
+          substituent = domain$substituent,
+          parents = as.integer(domain$parents)
         )
       }
     )
@@ -883,8 +883,8 @@ collapse_floating_substituent_positions <- function(positions) {
 #' @param occupied_slots Definitely occupied main-tree carbon slots.
 #' @param context Input-format context for error messages.
 #'
-#' @return An empty vector for an implicit all-main candidate set, otherwise
-#'   the feasible explicit candidate parents.
+#' @return A list containing the normalized substituent and candidate parents.
+#'   An empty parent vector represents an implicit all-main candidate set.
 #' @noRd
 normalize_floating_substituent_parents <- function(
   parents,
@@ -893,27 +893,49 @@ normalize_floating_substituent_parents <- function(
   occupied_slots,
   context
 ) {
-  if (setequal(parents, main_vertices)) {
-    return(integer())
-  }
-
   positions <- floating_substituent_positions(substituent)
   if (length(positions) == 0L) {
-    return(parents)
+    if (setequal(parents, main_vertices)) {
+      parents <- integer()
+    }
+    return(list(substituent = substituent, parents = parents))
   }
 
-  feasible <- purrr::map_lgl(parents, function(parent) {
+  feasible_positions <- purrr::map(parents, function(parent) {
     slots <- paste(parent, positions, sep = "\r")
-    any(!slots %in% occupied_slots)
+    positions[!slots %in% occupied_slots]
   })
-  parents <- parents[feasible]
+  feasible_parents <- lengths(feasible_positions) > 0L
+  parents <- parents[feasible_parents]
+  feasible_positions <- feasible_positions[feasible_parents]
   if (length(parents) == 0L) {
     cli::cli_abort(
       "No feasible parent remains for a {context} after excluding occupied carbon positions.",
       call = rlang::caller_env()
     )
   }
-  parents
+
+  position_sets <- purrr::map(
+    feasible_positions,
+    ~ sort(unique(.x))
+  )
+  if (length(unique(position_sets)) != 1L) {
+    cli::cli_abort(
+      "Can't represent the feasible parent-position combinations for a {context} after excluding occupied carbon positions.",
+      call = rlang::caller_env()
+    )
+  }
+
+  position <- collapse_floating_substituent_positions(position_sets[[1]])
+  substituent <- stringr::str_replace(
+    substituent,
+    "^[?0-9/]+",
+    position
+  )
+  if (setequal(parents, main_vertices)) {
+    parents <- integer()
+  }
+  list(substituent = substituent, parents = parents)
 }
 
 #' Normalize floating-part candidate parents

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -7,8 +7,8 @@
 #' GlycoCT format consists of:
 #' - RES: Contains monosaccharides (lines starting with 'b:') and substituents (lines starting with 's:')
 #' - LIN: Contains linkage information between residues
-#' - UND: Contains floating substructures whose attachment to the main glycan
-#'   is unresolved
+#' - UND: Contains floating substructures or substituents whose attachment to
+#'   the main glycan is unresolved
 #'
 #' Alditol residues are parsed as regular reducing-end glycans with unknown
 #' anomer configurations.
@@ -85,12 +85,25 @@ do_parse_glycoct <- function(x) {
     return(main_graph$graph)
   }
 
+  floating_substituents <- purrr::keep(
+    floating,
+    is_glycoct_floating_substituent
+  )
+  floating <- purrr::discard(
+    floating,
+    is_glycoct_floating_substituent
+  )
   floating_graphs <- purrr::map(
     floating,
     ~ build_glycoct_graph_data(.x$residues, .x$linkages)
   )
 
-  build_glycoct_floating_graph(main_graph, floating_graphs, floating)
+  build_glycoct_floating_graph(
+    main_graph,
+    floating_graphs,
+    floating,
+    floating_substituents
+  )
 }
 
 #' Split a GlycoCT record into its main and UND blocks
@@ -209,6 +222,17 @@ parse_glycoct_und_block <- function(lines) {
       child_pos = matches[3]
     )
   )
+}
+
+#' Detect a substituent-only GlycoCT UND block
+#'
+#' @param block Parsed UND block data.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_glycoct_floating_substituent <- function(block) {
+  length(block$residues) == 1L &&
+    identical(block$residues[[1]]$type, "sub")
 }
 
 #' Split a GlycoCT record into parser lines
@@ -570,10 +594,16 @@ format_glycoct_linkage <- function(parent_pos, child_pos, child_anomer) {
 #' @param main Main-tree graph data.
 #' @param floating_graphs Graph data for each floating subtree.
 #' @param floating Parsed UND metadata.
+#' @param floating_substituents Parsed substituent-only UND metadata.
 #'
 #' @return An annotated glycan forest understood by `glyrepr`.
 #' @noRd
-build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
+build_glycoct_floating_graph <- function(
+  main,
+  floating_graphs,
+  floating,
+  floating_substituents = list()
+) {
   graph_data <- c(list(main), floating_graphs)
   sizes <- purrr::map_int(graph_data, ~ igraph::vcount(.x$graph))
   offsets <- c(0L, utils::head(cumsum(sizes), -1L))
@@ -632,47 +662,101 @@ build_glycoct_floating_graph <- function(main, floating_graphs, floating) {
     main$graph,
     seq_along(main$original_ids)
   )
-  forest$floating_parts <- purrr::map2(
-    seq_along(floating_graphs),
-    floating,
-    function(part_id, metadata) {
-      data <- floating_graphs[[part_id]]
-      offset <- offsets[[part_id + 1L]]
-      root <- which(igraph::degree(data$graph, mode = "in") == 0)
-      parents <- unname(
-        main_parent_indices[as.character(metadata$parent_ids)]
-      )
-      if (anyNA(parents)) {
-        missing_ids <- metadata$parent_ids[is.na(parents)]
-        cli::cli_abort(c(
-          "GlycoCT UND candidate parents must be main-tree monosaccharides.",
-          "x" = "Can't find main-tree residue ID{?s} {.val {missing_ids}}."
-        ))
-      }
-
-      linkage <- format_glycoct_linkage(
-        metadata$parent_pos,
-        metadata$child_pos,
-        data$vertices[[root]]$anomer
-      )
-      parents <- normalize_floating_part_parents(
-        parents,
-        seq_along(main$original_ids),
-        linkage,
-        occupied_slots,
-        context = "GlycoCT UND part"
-      )
-
-      list(
-        root = as.integer(offset + root),
-        nodes = as.integer(offset + seq_len(sizes[[part_id + 1L]])),
-        linkage = linkage,
-        parents = as.integer(parents)
-      )
-    }
+  occupied_carbon_slots <- definitely_occupied_carbon_slots(
+    main$graph,
+    seq_along(main$original_ids)
   )
+  if (length(floating_graphs) > 0L) {
+    forest$floating_parts <- purrr::map2(
+      seq_along(floating_graphs),
+      floating,
+      function(part_id, metadata) {
+        data <- floating_graphs[[part_id]]
+        offset <- offsets[[part_id + 1L]]
+        root <- which(igraph::degree(data$graph, mode = "in") == 0)
+        parents <- map_glycoct_und_parents(
+          metadata$parent_ids,
+          main_parent_indices
+        )
+
+        linkage <- format_glycoct_linkage(
+          metadata$parent_pos,
+          metadata$child_pos,
+          data$vertices[[root]]$anomer
+        )
+        parents <- normalize_floating_part_parents(
+          parents,
+          seq_along(main$original_ids),
+          linkage,
+          occupied_slots,
+          context = "GlycoCT UND part"
+        )
+
+        list(
+          root = as.integer(offset + root),
+          nodes = as.integer(offset + seq_len(sizes[[part_id + 1L]])),
+          linkage = linkage,
+          parents = as.integer(parents)
+        )
+      }
+    )
+  }
+
+  if (length(floating_substituents) > 0L) {
+    main_vertices <- seq_along(main$original_ids)
+    forest$floating_substituents <- purrr::map(
+      floating_substituents,
+      function(metadata) {
+        parents <- map_glycoct_und_parents(
+          metadata$parent_ids,
+          main_parent_indices
+        )
+        positions <- stringr::str_split_1(
+          metadata$parent_pos,
+          stringr::fixed("|")
+        )
+        position <- collapse_floating_substituent_positions(positions)
+        substituent <- metadata$residues[[1]]$content
+        substituent <- paste0(
+          position,
+          glycoct_substituent_abbreviation(substituent)
+        )
+        parents <- normalize_floating_substituent_parents(
+          parents,
+          main_vertices,
+          substituent,
+          occupied_carbon_slots,
+          context = "GlycoCT UND substituent"
+        )
+
+        list(
+          substituent = substituent,
+          parents = as.integer(parents)
+        )
+      }
+    )
+  }
 
   forest
+}
+
+#' Map GlycoCT UND parent IDs to main-tree graph indices
+#'
+#' @param parent_ids GlycoCT residue IDs declared by an UND block.
+#' @param main_parent_indices Named main-tree graph indices.
+#'
+#' @return Integer main-tree graph indices.
+#' @noRd
+map_glycoct_und_parents <- function(parent_ids, main_parent_indices) {
+  parents <- unname(main_parent_indices[as.character(parent_ids)])
+  if (anyNA(parents)) {
+    missing_ids <- parent_ids[is.na(parents)]
+    cli::cli_abort(c(
+      "GlycoCT UND candidate parents must be main-tree monosaccharides.",
+      "x" = "Can't find main-tree residue ID{?s} {.val {missing_ids}}."
+    ))
+  }
+  as.integer(parents)
 }
 
 #' Find definitely occupied acceptor slots in a glycan tree
@@ -717,6 +801,119 @@ linkage_acceptor_positions <- function(linkage) {
   }
 
   stringr::str_split(acceptor, stringr::fixed("/"))[[1]]
+}
+
+#' Find definitely occupied carbon slots in a glycan tree
+#'
+#' @param graph A parsed glycan graph.
+#' @param vertices Vertices belonging to the tree of interest.
+#'
+#' @return Character keys combining parent vertex and carbon position.
+#' @noRd
+definitely_occupied_carbon_slots <- function(
+  graph,
+  vertices = seq_len(igraph::vcount(graph))
+) {
+  edge_slots <- definitely_occupied_acceptor_slots(graph, vertices)
+  substituent_slots <- purrr::map(
+    vertices,
+    function(vertex) {
+      substituents <- igraph::vertex_attr(graph, "sub", index = vertex)
+      if (identical(substituents, "")) {
+        return(character())
+      }
+      tokens <- stringr::str_split_1(
+        substituents,
+        stringr::fixed(",")
+      )
+      positions <- purrr::map(
+        tokens,
+        floating_substituent_positions
+      )
+      definite <- lengths(positions) == 1L
+      paste(
+        vertex,
+        unlist(positions[definite], use.names = FALSE),
+        sep = "\r"
+      )
+    }
+  )
+
+  unique(c(
+    edge_slots,
+    unlist(substituent_slots, use.names = FALSE)
+  ))
+}
+
+#' Extract possible carbon positions from a substituent token
+#'
+#' @param substituent One substituent token.
+#'
+#' @return A character vector. Unknown positions return an empty vector.
+#' @noRd
+floating_substituent_positions <- function(substituent) {
+  position <- stringr::str_extract(substituent, "^[?0-9/]+")
+  if (
+    is.na(position) ||
+      stringr::str_detect(position, stringr::fixed("?"))
+  ) {
+    return(character())
+  }
+  stringr::str_split_1(position, stringr::fixed("/"))
+}
+
+#' Collapse source-format substituent positions into one glyrepr position
+#'
+#' @param positions Source-format carbon positions.
+#'
+#' @return A canonical position string.
+#' @noRd
+collapse_floating_substituent_positions <- function(positions) {
+  if (any(positions %in% c("?", "-1"))) {
+    return("?")
+  }
+  paste(sort(unique(as.integer(positions))), collapse = "/")
+}
+
+#' Normalize floating-substituent candidate parents
+#'
+#' @param parents Declared main-tree candidate vertex indices.
+#' @param main_vertices Every main-tree vertex index.
+#' @param substituent A floating substituent token.
+#' @param occupied_slots Definitely occupied main-tree carbon slots.
+#' @param context Input-format context for error messages.
+#'
+#' @return An empty vector for an implicit all-main candidate set, otherwise
+#'   the feasible explicit candidate parents.
+#' @noRd
+normalize_floating_substituent_parents <- function(
+  parents,
+  main_vertices,
+  substituent,
+  occupied_slots,
+  context
+) {
+  if (setequal(parents, main_vertices)) {
+    return(integer())
+  }
+
+  positions <- floating_substituent_positions(substituent)
+  if (length(positions) == 0L) {
+    return(parents)
+  }
+
+  feasible <- purrr::map_lgl(parents, function(parent) {
+    slots <- paste(parent, positions, sep = "\r")
+    any(!slots %in% occupied_slots)
+  })
+  parents <- parents[feasible]
+  if (length(parents) == 0L) {
+    cli::cli_abort(
+      "No feasible parent remains for a {context} after excluding occupied carbon positions.",
+      call = rlang::caller_env()
+    )
+  }
+  parents
 }
 
 #' Normalize floating-part candidate parents
@@ -2069,30 +2266,29 @@ format_extra_substituents <- function(extra_subs, group, residues, linkages) {
     }
 
     # Format the substituent with position
-    if (sub_content == "sulfate") {
-      formatted <- c(formatted, paste0(position, "S"))
-    } else if (sub_content == "n-acetyl") {
-      formatted <- c(formatted, paste0(position, "Ac"))
-    } else if (sub_content == "acetyl") {
-      formatted <- c(formatted, paste0(position, "Ac"))
-    } else if (sub_content == "methyl") {
-      formatted <- c(formatted, paste0(position, "Me"))
-    } else if (sub_content == "amino") {
-      formatted <- c(formatted, paste0(position, "N"))
-    } else if (sub_content == "phosphate") {
-      formatted <- c(formatted, paste0(position, "P"))
-    } else if (sub_content == "phospho-ethanolamine") {
-      formatted <- c(formatted, paste0(position, "PEtn"))
-    } else if (sub_content == "diphospho-ethanolamine") {
-      formatted <- c(formatted, paste0(position, "PPEtn"))
-    } else {
-      # Generic format - for unknown substituents, use the raw name
-      formatted <- c(formatted, paste0(position, sub_content))
-    }
+    formatted <- c(
+      formatted,
+      paste0(position, glycoct_substituent_abbreviation(sub_content))
+    )
   }
 
   # Join multiple substituents
   paste(formatted, collapse = ",")
+}
+
+glycoct_substituent_abbreviation <- function(x) {
+  switch(
+    x,
+    sulfate = "S",
+    `n-acetyl` = "Ac",
+    acetyl = "Ac",
+    methyl = "Me",
+    amino = "N",
+    phosphate = "P",
+    `phospho-ethanolamine` = "PEtn",
+    `diphospho-ethanolamine` = "PPEtn",
+    x
+  )
 }
 
 matches_glycoct_pattern <- function(group, residues, linkages, mapping) {

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -1022,6 +1022,11 @@ parse_wurcs_floating_candidates <- function(x, source, context) {
 
 
 parse_wurcs_substituent_name <- function(x) {
+  x <- stringr::str_replace(
+    x,
+    "^NSO/3=O/3=O$",
+    "OSO/3=O/3=O"
+  )
   patterns <- paste0("^(?:", WURCS_SUB_REGEX, ")$")
   sub_idx <- purrr::detect_index(
     patterns,

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -7,6 +7,8 @@
 #' anomer configurations.
 #' Ambiguous alternative linkage groups are represented as floating glycan
 #' parts when their child residue or subtree is not localized to one parent.
+#' Floating substituents preserve their chemistry, carbon-position ambiguity,
+#' and candidate parent residues.
 #'
 #' @param x A character vector of WURCS strings. NA values are allowed and will be returned as NA structures.
 #' @param on_failure How to handle parsing failures. `"error"` aborts when a
@@ -908,31 +910,93 @@ parse_linkages <- function(x) {
 
 parse_wurcs_linkages <- function(x, residues) {
   linkages <- stringr::str_split_1(x, "_")
-  floating <- stringr::str_detect(linkages, stringr::fixed("}"))
+  is_floating <- stringr::str_detect(linkages, stringr::fixed("}"))
+  floating <- purrr::map(
+    linkages[is_floating],
+    parse_wurcs_floating_linkage
+  )
+  floating_types <- purrr::map_chr(floating, "type")
 
   list(
     ordinary = purrr::map(
-      linkages[!floating],
+      linkages[!is_floating],
       parse_one_linkage,
       anomers = purrr::map_chr(residues, "anomer")
     ),
-    floating = purrr::map(linkages[floating], parse_wurcs_floating_linkage)
+    floating = purrr::map(
+      floating[floating_types == "part"],
+      "metadata"
+    ),
+    floating_substituents = purrr::map(
+      floating[floating_types == "substituent"],
+      "metadata"
+    )
   )
 }
 
 
 parse_wurcs_floating_linkage <- function(x) {
-  linkage <- stringr::str_remove(x, stringr::fixed("}"))
-  parts <- stringr::str_split_1(linkage, stringr::fixed("-"))
-  if (length(parts) != 2L) {
+  brace_parts <- stringr::str_split_1(x, stringr::fixed("}"))
+  if (length(brace_parts) != 2L) {
     cli::cli_abort(
-      "Floating WURCS substituents are not supported: {.str {x}}"
+      "Can't parse floating WURCS linkage: {.str {x}}"
     )
   }
 
+  if (stringr::str_starts(brace_parts[[2]], stringr::fixed("*"))) {
+    candidates <- parse_wurcs_floating_candidates(
+      brace_parts[[1]],
+      x,
+      context = "substituent"
+    )
+    sub_code <- stringr::str_remove(brace_parts[[2]], "^\\*")
+    substituent <- parse_wurcs_substituent_name(sub_code)
+    position <- collapse_floating_substituent_positions(
+      candidates$positions
+    )
+
+    return(list(
+      type = "substituent",
+      metadata = list(
+        substituent = paste0(position, substituent),
+        parents = candidates$parents
+      )
+    ))
+  }
+  if (brace_parts[[2]] != "") {
+    cli::cli_abort(
+      "Can't parse floating WURCS linkage: {.str {x}}"
+    )
+  }
+
+  parts <- stringr::str_split_1(brace_parts[[1]], stringr::fixed("-"))
+  if (length(parts) != 2L) {
+    cli::cli_abort(
+      "Can't parse floating WURCS linkage: {.str {x}}"
+    )
+  }
   child <- parse_wurcs_linkage_endpoint(parts[[1]])
+  candidates <- parse_wurcs_floating_candidates(
+    parts[[2]],
+    x,
+    context = "linkage"
+  )
+
+  list(
+    type = "part",
+    metadata = list(
+      root = child$node,
+      child_position = child$position,
+      parent_positions = candidates$positions,
+      parents = candidates$parents
+    )
+  )
+}
+
+
+parse_wurcs_floating_candidates <- function(x, source, context) {
   candidates <- purrr::map(
-    stringr::str_split_1(parts[[2]], stringr::fixed("|")),
+    stringr::str_split_1(x, stringr::fixed("|")),
     parse_wurcs_linkage_endpoint
   )
   candidate_nodes <- purrr::map_int(candidates, "node")
@@ -946,16 +1010,27 @@ parse_wurcs_floating_linkage <- function(x) {
   )
   if (length(unique(position_sets)) != 1L) {
     cli::cli_abort(
-      "Floating WURCS linkages with parent-specific acceptor positions are not supported: {.str {x}}"
+      "Floating WURCS {context}s with parent-specific positions are not supported: {.str {source}}"
     )
   }
 
   list(
-    root = child$node,
-    child_position = child$position,
-    parent_positions = position_sets[[1]],
+    positions = position_sets[[1]],
     parents = unique(candidate_nodes)
   )
+}
+
+
+parse_wurcs_substituent_name <- function(x) {
+  patterns <- paste0("^(?:", WURCS_SUB_REGEX, ")$")
+  sub_idx <- purrr::detect_index(
+    patterns,
+    ~ stringr::str_detect(x, .x)
+  )
+  if (sub_idx == 0L) {
+    cli::cli_abort("Unable to parse floating substituent: {.str {x}}")
+  }
+  names(WURCS_SUB_REGEX)[[sub_idx]]
 }
 
 
@@ -1063,7 +1138,12 @@ prepare_graph_dfs <- function(residues, linkages) {
 }
 
 
-build_glycan_graph <- function(edgelist_df, vertex_df, floating = list()) {
+build_glycan_graph <- function(
+  edgelist_df,
+  vertex_df,
+  floating = list(),
+  floating_substituents = list()
+) {
   # For format of input values, see `prepare_graph_dfs`.
   graph <- igraph::graph_from_data_frame(
     edgelist_df,
@@ -1071,6 +1151,13 @@ build_glycan_graph <- function(edgelist_df, vertex_df, floating = list()) {
   )
   if (length(floating) > 0) {
     graph <- annotate_wurcs_floating_parts(graph, vertex_df, floating)
+  }
+  if (length(floating_substituents) > 0) {
+    graph <- annotate_wurcs_floating_substituents(
+      graph,
+      floating,
+      floating_substituents
+    )
   }
   floating_roots <- purrr::map_int(floating, "root")
   core_node <- igraph::V(graph)[
@@ -1080,6 +1167,53 @@ build_glycan_graph <- function(edgelist_df, vertex_df, floating = list()) {
   core_anomer <- vertex_df$anomer[as.numeric(core_node)]
   graph$anomer <- core_anomer
   graph$alditol <- FALSE # Not implemented yet
+  graph
+}
+
+
+annotate_wurcs_floating_substituents <- function(
+  graph,
+  floating,
+  substituents
+) {
+  components <- igraph::components(graph, mode = "weak")$membership
+  floating_components <- components[purrr::map_int(floating, "root")]
+  floating_nodes <- which(components %in% floating_components)
+  main_vertices <- as.integer(setdiff(
+    seq_len(igraph::vcount(graph)),
+    floating_nodes
+  ))
+  occupied_slots <- definitely_occupied_carbon_slots(
+    graph,
+    main_vertices
+  )
+
+  graph$floating_substituents <- purrr::map(
+    substituents,
+    function(metadata) {
+      non_main_parents <- setdiff(metadata$parents, main_vertices)
+      if (length(non_main_parents) > 0L) {
+        cli::cli_abort(c(
+          "WURCS floating substituent candidate parents must be main-tree monosaccharides.",
+          "x" = "Candidate node{?s} {.val {non_main_parents}} belong{?s/} to a floating subtree."
+        ))
+      }
+      parents <- metadata$parents
+      parents <- normalize_floating_substituent_parents(
+        parents,
+        main_vertices,
+        metadata$substituent,
+        occupied_slots,
+        context = "WURCS floating substituent"
+      )
+
+      list(
+        substituent = metadata$substituent,
+        parents = as.integer(parents)
+      )
+    }
+  )
+
   graph
 }
 
@@ -1182,17 +1316,20 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
   if (linkage_part == "") {
     linkages <- NULL
     floating <- list()
+    floating_substituents <- list()
   } else {
     linkage_data <- parse_wurcs_linkages(linkage_part, residues)
     linkages <- linkage_data$ordinary
     floating <- linkage_data$floating
+    floating_substituents <- linkage_data$floating_substituents
   }
 
   graph_dfs <- prepare_graph_dfs(residues, linkages)
   graph <- build_glycan_graph(
     graph_dfs$edgelist,
     graph_dfs$vertex,
-    floating = floating
+    floating = floating,
+    floating_substituents = floating_substituents
   )
   graph
 }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -1199,7 +1199,7 @@ annotate_wurcs_floating_substituents <- function(
         ))
       }
       parents <- metadata$parents
-      parents <- normalize_floating_substituent_parents(
+      domain <- normalize_floating_substituent_parents(
         parents,
         main_vertices,
         metadata$substituent,
@@ -1208,8 +1208,8 @@ annotate_wurcs_floating_substituents <- function(
       )
 
       list(
-        substituent = metadata$substituent,
-        parents = as.integer(parents)
+        substituent = domain$substituent,
+        parents = as.integer(domain$parents)
       )
     }
   )

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -39,8 +39,8 @@ GlycoCT format consists of:
 \itemize{
 \item RES: Contains monosaccharides (lines starting with 'b:') and substituents (lines starting with 's:')
 \item LIN: Contains linkage information between residues
-\item UND: Contains floating substructures whose attachment to the main glycan
-is unresolved
+\item UND: Contains floating substructures or substituents whose attachment to
+the main glycan is unresolved
 }
 
 Alditol residues are parsed as regular reducing-end glycans with unknown

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -38,6 +38,8 @@ Alditol residues are parsed as regular reducing-end glycans with unknown
 anomer configurations.
 Ambiguous alternative linkage groups are represented as floating glycan
 parts when their child residue or subtree is not localized to one parent.
+Floating substituents preserve their chemistry, carbon-position ambiguity,
+and candidate parent residues.
 }
 \examples{
 wurcs <- paste0(

--- a/tests/testthat/_snaps/parse-glycoct.md
+++ b/tests/testthat/_snaps/parse-glycoct.md
@@ -1,3 +1,12 @@
+# floating substituent positions preserve representable domains
+
+    Code
+      normalize_floating_substituent_parents(c(1L, 2L), c(1L, 2L), "3/6S", c("1\r3",
+        "2\r6"), context = "test substituent")
+    Condition
+      Error:
+      ! Can't represent the feasible parent-position combinations for a test substituent after excluding occupied carbon positions.
+
 # GlycoCT UND donor alternatives fail explicitly
 
     Code

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -778,6 +778,58 @@ test_that("single-parent GlycoCT UND substituents become ordinary", {
   )
 })
 
+test_that("all-main GlycoCT substituent candidates exclude occupied slots", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(3+1)n",
+    "RES",
+    "3s:sulfate"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(
+    unname(as.character(result)),
+    "Glc3S(b1-3)Gal(a1-"
+  )
+  expect_identical(
+    unname(glyrepr::has_floating_substituents(result)),
+    FALSE
+  )
+})
+
+test_that("floating substituent positions preserve representable domains", {
+  normalized <- normalize_floating_substituent_parents(
+    c(1L, 2L),
+    c(1L, 2L),
+    "3/6S",
+    c("1\r3", "2\r3"),
+    context = "test substituent"
+  )
+
+  expect_identical(
+    normalized,
+    list(substituent = "6S", parents = integer())
+  )
+  expect_snapshot(
+    error = TRUE,
+    normalize_floating_substituent_parents(
+      c(1L, 2L),
+      c(1L, 2L),
+      "3/6S",
+      c("1\r3", "2\r6"),
+      context = "test substituent"
+    )
+  )
+})
+
 test_that("GlycoCT supports floating parts and substituents together", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -731,6 +731,89 @@ test_that("GlycoCT UND sections become floating glycan parts", {
   expect_equal(floating$parents, list(integer(), integer()))
 })
 
+test_that("substituent-only GlycoCT UND sections become floating", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(-1+1)n",
+    "RES",
+    "3s:sulfate"
+  )
+
+  result <- parse_glycoct(glycoct)
+  floating <- glyrepr::structure_floating_substituents(result)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{?S}Glc(b1-3)Gal(a1-"
+  )
+  expect_identical(floating$substituent, "?S")
+  expect_equal(floating$parents, list(integer()))
+})
+
+test_that("single-parent GlycoCT UND substituents become ordinary", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1",
+    "SubtreeLinkageID1:o(3+1)n",
+    "RES",
+    "2s:sulfate"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(unname(as.character(result)), "Gal3S(a1-")
+  expect_identical(
+    unname(glyrepr::has_floating_substituents(result)),
+    FALSE
+  )
+})
+
+test_that("GlycoCT supports floating parts and substituents together", {
+  glycoct <- paste(
+    "RES",
+    "1b:a-dgal-HEX-1:5",
+    "2b:b-dglc-HEX-1:5",
+    "LIN",
+    "1:1o(3+1)2d",
+    "UND",
+    "UND1:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(6+1)d",
+    "RES",
+    "3b:a-lgal-HEX-1:5|6:d",
+    "UND2:100.0:100.0",
+    "ParentIDs:1|2",
+    "SubtreeLinkageID1:o(-1+1)n",
+    "RES",
+    "4s:sulfate"
+  )
+
+  result <- parse_glycoct(glycoct)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{?S}{Fuc(a1-6)}Glc(b1-3)Gal(a1-"
+  )
+  expect_identical(
+    glyrepr::structure_floating_substituents(result)$substituent,
+    "?S"
+  )
+  expect_identical(
+    glyrepr::structure_floating_parts(result)$linkage,
+    "a1-6"
+  )
+})
+
 test_that("GlycoCT warns for alditols inside UND sections", {
   glycoct <- paste(
     "RES",

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1393,12 +1393,16 @@ test_that("parse_wurcs maps floating substituent chemistry", {
   ambiguous <- parse_wurcs_floating_linkage(
     "a6|a4|b4|b6}*OSO/3=O/3=O"
   )
+  n_sulfate <- parse_wurcs_floating_linkage(
+    "a2}*NSO/3=O/3=O"
+  )
 
   expect_identical(
     unname(parsed),
     paste0("?", names(codes))
   )
   expect_identical(ambiguous$metadata$substituent, "4/6S")
+  expect_identical(n_sulfate$metadata$substituent, "2S")
 })
 
 
@@ -1415,6 +1419,18 @@ test_that("single-parent WURCS floating substituents become ordinary", {
     unname(glyrepr::has_floating_substituents(result)),
     FALSE
   )
+})
+
+
+test_that("floating WURCS N-sulfates use sulfate chemistry", {
+  wurcs <- paste0(
+    "WURCS=2.0/1,1,1/[a2112h-1a_1-5]/1/",
+    "a2}*NSO/3=O/3=O"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(unname(as.character(result)), "Gal2S(a1-")
 })
 
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1418,6 +1418,26 @@ test_that("single-parent WURCS floating substituents become ordinary", {
 })
 
 
+test_that("all-main WURCS substituent candidates exclude occupied slots", {
+  wurcs <- paste0(
+    "WURCS=2.0/2,2,2/",
+    "[a2112h-1a_1-5][a2122h-1a_1-5]/",
+    "1-2/a3-b1_a3|b3}*OSO/3=O/3=O"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "Glc3S(a1-3)Gal(a1-"
+  )
+  expect_identical(
+    unname(glyrepr::has_floating_substituents(result)),
+    FALSE
+  )
+})
+
+
 test_that("parse_wurcs orients uncertain edges inside floating subtrees", {
   wurcs <- paste0(
     "WURCS=2.0/4,4,3/",

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1320,6 +1320,104 @@ test_that("parse_wurcs preserves multiple floating subtrees", {
 })
 
 
+test_that("parse_wurcs supports floating substituents", {
+  restricted <- paste0(
+    "WURCS=2.0/3,3,3/",
+    "[a2112h-1a_1-5][a2122h-1a_1-5][a1122h-1a_1-5]/",
+    "1-2-3/b3|c3}*OSO/3=O/3=O_a3-b1_b4-c1"
+  )
+  multiple <- paste0(
+    "WURCS=2.0/3,3,4/",
+    "[a2112h-1a_1-5][a2122h-1a_1-5][a1122h-1a_1-5]/",
+    "1-2-3/a?|b?|c?}*OPO/3O/3=O_",
+    "a?|b?|c?}*OSO/3=O/3=O_a3-b1_b4-c1"
+  )
+
+  restricted_result <- parse_wurcs(restricted)
+  multiple_result <- parse_wurcs(multiple)
+
+  expect_identical(
+    unname(as.character(restricted_result)),
+    "{3S|1,2}Man(a1-4)Glc(a1-3)Gal(a1-"
+  )
+  expect_equal(
+    glyrepr::structure_floating_substituents(
+      restricted_result
+    )$parents,
+    list(c(1L, 2L))
+  )
+  expect_identical(
+    unname(as.character(multiple_result)),
+    "{?P}{?S}Man(a1-4)Glc(a1-3)Gal(a1-"
+  )
+})
+
+
+test_that("parse_wurcs supports floating parts and substituents together", {
+  wurcs <- paste0(
+    "WURCS=2.0/3,3,3/",
+    "[a2122h-1x_1-5][a2112h-1b_1-5]",
+    "[Aad21122h-2a_2-6_5*NCC/3=O]/",
+    "1-2-3/a4-b1_a?|b?}*OSO/3=O/3=O_c2-a6|b6}"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(
+    unname(as.character(result)),
+    "{?S}{Neu5Ac(a2-6)}Gal(b1-4)Glc(?1-"
+  )
+  expect_identical(
+    glyrepr::structure_floating_substituents(result)$substituent,
+    "?S"
+  )
+  expect_identical(
+    glyrepr::structure_floating_parts(result)$linkage,
+    "a2-6"
+  )
+})
+
+
+test_that("parse_wurcs maps floating substituent chemistry", {
+  codes <- c(
+    Me = "OC",
+    Ac = "OCC/3=O",
+    P = "OPO/3O/3=O",
+    S = "OSO/3=O/3=O",
+    PEtn = "OP^XOCCN/3O/3=O"
+  )
+  parsed <- purrr::map_chr(codes, function(code) {
+    linkage <- paste0("a?|b?}*", code)
+    parse_wurcs_floating_linkage(linkage)$metadata$substituent
+  })
+  ambiguous <- parse_wurcs_floating_linkage(
+    "a6|a4|b4|b6}*OSO/3=O/3=O"
+  )
+
+  expect_identical(
+    unname(parsed),
+    paste0("?", names(codes))
+  )
+  expect_identical(ambiguous$metadata$substituent, "4/6S")
+})
+
+
+test_that("single-parent WURCS floating substituents become ordinary", {
+  wurcs <- paste0(
+    "WURCS=2.0/1,1,1/[a2112h-1a_1-5]/1/",
+    "a3}*OSO/3=O/3=O"
+  )
+
+  result <- parse_wurcs(wurcs)
+
+  expect_identical(unname(as.character(result)), "Gal3S(a1-")
+  expect_identical(
+    unname(glyrepr::has_floating_substituents(result)),
+    FALSE
+  )
+})
+
+
 test_that("parse_wurcs orients uncertain edges inside floating subtrees", {
   wurcs <- paste0(
     "WURCS=2.0/4,4,3/",


### PR DESCRIPTION
## Summary

- Parse substituent-only GlycoCT UND blocks as floating substituents.
- Parse WURCS floating substituent linkages while preserving chemistry, carbon positions, and candidate parents.
- Support floating substituents alongside floating glycan parts and canonicalize singleton candidates.
- Filter occupied parent-position domains before implicit candidate encoding and reject correlations that cannot be represented faithfully.
- Normalize floating WURCS N-sulfate MAP codes to sulfate chemistry.
- Add documentation and regression coverage.

## Verification

- `devtools::test()` — 1,644 expectations passed
- `pkgdown::check_pkgdown()` — passed
- `devtools::check(document = FALSE, error_on = "never")` — 0 errors, 0 warnings, 1 environment-only clock NOTE
- Re-audited 1,054 WURCS documentation rows containing floating substituents; no new correlation errors
- Re-audited all 5,994 GlycoCT documentation rows containing UND sections; 5,549 parse successfully and the existing 445 failures are unchanged
- The documentation corpus contains no floating WURCS N-sulfate case, so dedicated metadata and end-to-end regressions cover that valid edge case
- No floating-substituent-specific corpus regressions identified