### PR TITLE
feat: preserve alditol reducing ends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyparse (development version)
 
+* `parse_glycoct()`, `parse_wurcs()`, `parse_iupac_compact()`, `parse_iupac_condensed()`, `parse_linucs()`, and `auto_parse()` now preserve alditol reducing ends in parsed structures.
 * `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents. (#45)
 * Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43, #44)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* `parse_glycoct()`, `parse_wurcs()`, `parse_iupac_compact()`, `parse_iupac_condensed()`, `parse_linucs()`, and `auto_parse()` now preserve alditol reducing ends in parsed structures.
+* `parse_glycoct()`, `parse_wurcs()`, `parse_iupac_compact()`, `parse_iupac_condensed()`, `parse_linucs()`, and `auto_parse()` now preserve alditol reducing ends in parsed structures. (#46)
 * `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents. (#45)
 * Parsers now preserve unusual monosaccharide configurations using `glyrepr` names such as `D-Fuc`, `L-Gul`, and `D-Fucf`, while unprefixed names retain their natural configurations. (#43, #44)
 * Parsers now preserve explicit furanose forms as `glyrepr` monosaccharide names such as `Galf`, `GlcfNAc`, and `Neuf5Ac` across IUPAC, GlyCAM IUPAC, GlycoCT, WURCS, LINUCS, Linear Code, and KCF inputs. (#41)

--- a/R/auto-parse.R
+++ b/R/auto-parse.R
@@ -75,6 +75,8 @@ choose_parser <- function(x) {
     return(do_parse_strucgp_struc)
   } else if (stringr::str_ends(x, "-OH")) {
     return(do_parse_glycam_iupac)
+  } else if (stringr::str_ends(x, stringr::fixed("-ol"))) {
+    return(do_parse_iupac_condensed)
   } else if (
     stringr::str_detect(x, "\\u2192") || # Unicode arrow →
       stringr::str_detect(x, "->") || # Plain text arrow ->

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -71,14 +71,20 @@ do_parse_glycoct <- function(x) {
 
   main <- parse_glycoct_block(blocks$main)
   floating <- purrr::map(blocks$floating, parse_glycoct_und_block)
+  main_graph <- build_glycoct_graph_data(main$residues, main$linkages)
+  main_alditol_count <- sum(purrr::map_lgl(
+    main_graph$vertices,
+    ~ isTRUE(.x$is_alditol)
+  ))
+  has_unrepresented_main_alditol <- main_alditol_count >
+    as.integer(isTRUE(main_graph$graph$alditol))
   has_floating_alditol <- any(purrr::map_lgl(
     floating,
     ~ has_glycoct_alditol_residue(.x$residues)
   ))
-  if (has_floating_alditol) {
-    warn_glycoct_floating_alditol()
+  if (has_unrepresented_main_alditol || has_floating_alditol) {
+    warn_glycoct_unrepresented_alditol()
   }
-  main_graph <- build_glycoct_graph_data(main$residues, main$linkages)
 
   if (length(blocks$floating) == 0) {
     return(main_graph$graph)
@@ -319,14 +325,14 @@ has_glycoct_alditol_residue <- function(residues) {
   ))
 }
 
-#' Warn about floating alditol normalization in GlycoCT parsing
+#' Warn about unrepresented alditol normalization in GlycoCT parsing
 #'
 #' @return `NULL`, invisibly.
 #' @noRd
-warn_glycoct_floating_alditol <- function() {
+warn_glycoct_unrepresented_alditol <- function() {
   cli::cli_warn(c(
     "Only the main reducing-end GlycoCT residue can retain alditol status.",
-    "i" = "Alditol residues in UND sections are parsed as regular residues."
+    "i" = "Other alditol residues are parsed as regular residues."
   ))
   invisible(NULL)
 }

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -10,8 +10,8 @@
 #' - UND: Contains floating substructures or substituents whose attachment to
 #'   the main glycan is unresolved
 #'
-#' Alditol residues are parsed as regular reducing-end glycans with unknown
-#' anomer configurations.
+#' Main reducing-end alditol residues retain their alditol status and use an
+#' unknown anomer configuration.
 #'
 #' For more information about GlycoCT format, see the glycoct.md documentation.
 #'
@@ -71,13 +71,12 @@ do_parse_glycoct <- function(x) {
 
   main <- parse_glycoct_block(blocks$main)
   floating <- purrr::map(blocks$floating, parse_glycoct_und_block)
-  has_alditol <- has_glycoct_alditol_residue(main$residues) ||
-    any(purrr::map_lgl(
-      floating,
-      ~ has_glycoct_alditol_residue(.x$residues)
-    ))
-  if (has_alditol) {
-    warn_glycoct_alditol()
+  has_floating_alditol <- any(purrr::map_lgl(
+    floating,
+    ~ has_glycoct_alditol_residue(.x$residues)
+  ))
+  if (has_floating_alditol) {
+    warn_glycoct_floating_alditol()
   }
   main_graph <- build_glycoct_graph_data(main$residues, main$linkages)
 
@@ -304,8 +303,7 @@ parse_res_section <- function(res_lines) {
 #' @return A logical scalar.
 #' @noRd
 is_glycoct_alditol_mono <- function(content) {
-  isTRUE(stringr::str_detect(content, "-0:0")) &&
-    isTRUE(stringr::str_detect(content, "\\|1:aldi"))
+  isTRUE(stringr::str_detect(content, "\\|1:aldi"))
 }
 
 #' Check whether parsed GlycoCT residues contain an alditol
@@ -321,14 +319,14 @@ has_glycoct_alditol_residue <- function(residues) {
   ))
 }
 
-#' Warn about alditol normalization in GlycoCT parsing
+#' Warn about floating alditol normalization in GlycoCT parsing
 #'
 #' @return `NULL`, invisibly.
 #' @noRd
-warn_glycoct_alditol <- function() {
+warn_glycoct_floating_alditol <- function() {
   cli::cli_warn(c(
-    "Alditol GlycoCT residues are parsed as regular reducing-end glycans with unknown anomer configurations.",
-    "i" = "For example, GlcNAc-ol is returned as GlcNAc(?1-."
+    "Only the main reducing-end GlycoCT residue can retain alditol status.",
+    "i" = "Alditol residues in UND sections are parsed as regular residues."
   ))
   invisible(NULL)
 }
@@ -556,7 +554,7 @@ build_glycoct_graph_data <- function(residues, linkages) {
   } else {
     g$anomer <- "?1"
   }
-  g$alditol <- FALSE
+  g$alditol <- !is.null(reducing_end) && isTRUE(reducing_end$is_alditol)
 
   list(
     graph = g,
@@ -652,7 +650,7 @@ build_glycoct_floating_graph <- function(
     use.names = FALSE
   )
   forest$anomer <- main$graph$anomer
-  forest$alditol <- FALSE
+  forest$alditol <- isTRUE(main$graph$alditol)
 
   main_parent_indices <- stats::setNames(
     seq_along(main$original_ids),

--- a/R/parse-iupac-compact.R
+++ b/R/parse-iupac-compact.R
@@ -9,8 +9,8 @@
 #' notation into IUPAC-condensed notation, then uses the IUPAC-condensed parser
 #' to construct the glycan structure.
 #'
-#' Alditol glycans are parsed as regular reducing-end glycans with unknown
-#' anomer configurations.
+#' Alditol glycans marked with `+aldi` retain their alditol status and use an
+#' unknown reducing-end anomer configuration.
 #'
 #' @param x A character vector of IUPAC-compact strings. NA values are allowed
 #'   and will be returned as NA structures.
@@ -64,10 +64,6 @@ do_parse_iupac_compact <- function(x) {
 #' @return A character vector containing IUPAC-condensed notation.
 #' @noRd
 convert_iupac_compact_to_condensed <- function(x) {
-  if (any(is_iupac_compact_alditol(x))) {
-    warn_iupac_compact_alditol()
-  }
-
   x |>
     normalize_iupac_compact_aliases() |>
     normalize_iupac_compact_modifiers() |>
@@ -148,8 +144,8 @@ normalize_iupac_compact_linkages <- function(x) {
 #'
 #' @param x A character vector of partially normalized IUPAC-compact strings.
 #'
-#' @return A character vector with alditol suffixes removed and reducing-end
-#'   anomer set to unknown.
+#' @return A character vector with alditol suffixes converted to `-ol` and
+#'   reducing-end anomers set to unknown.
 #' @noRd
 normalize_iupac_compact_alditol <- function(x) {
   alditol <- is_iupac_compact_alditol(x)
@@ -163,7 +159,7 @@ normalize_iupac_compact_alditol <- function(x) {
     if (is.null(terminal)) {
       return(value)
     }
-    replacement <- paste0(terminal$mono, terminal$modifiers)
+    replacement <- paste0(terminal$mono, terminal$modifiers, "-ol")
     stringr::str_replace(value, iupac_compact_terminal_pattern(), replacement)
   })
   x
@@ -185,11 +181,15 @@ normalize_iupac_compact_terminal <- function(x) {
 
   mono <- terminal_match[matched, "mono"]
   modifiers <- terminal_match[matched, "modifiers"]
+  alditol <- terminal_match[matched, "alditol"]
+  alditol[is.na(alditol)] <- ""
   anomer <- terminal_match[matched, "anomer"]
   anomer[is.na(anomer)] <- "?"
 
   anomer_pos <- iupac_compact_default_anomer_pos(mono)
-  terminal <- stringr::str_glue("{mono}{modifiers}({anomer}{anomer_pos}-")
+  terminal <- stringr::str_glue(
+    "{mono}{modifiers}{alditol}({anomer}{anomer_pos}-"
+  )
   x[matched] <- stringr::str_replace(
     x[matched],
     iupac_compact_terminal_pattern(),
@@ -207,19 +207,6 @@ normalize_iupac_compact_terminal <- function(x) {
 #' @noRd
 is_iupac_compact_alditol <- function(x) {
   stringr::str_ends(x, stringr::fixed("+aldi"))
-}
-
-
-#' Warn about alditol normalization in IUPAC-compact parsing.
-#'
-#' @return `NULL`, invisibly.
-#' @noRd
-warn_iupac_compact_alditol <- function() {
-  cli::cli_warn(c(
-    "Alditol IUPAC-compact glycans are parsed as regular reducing-end glycans with unknown anomer configurations.",
-    "i" = "For example, Glc-ol is returned as Glc(?1-."
-  ))
-  invisible(NULL)
 }
 
 
@@ -310,6 +297,7 @@ iupac_compact_terminal_pattern <- function() {
     "(?<modifiers>(?:",
     iupac_compact_modifier_pattern(),
     ")*)",
+    "(?<alditol>-ol)?",
     "(?<anomer>[ab\\?])?",
     "$"
   )

--- a/R/parse-linucs.R
+++ b/R/parse-linucs.R
@@ -10,6 +10,7 @@
 #' linkage position on the parent residue and `child` is the anomeric linkage
 #' position on the child residue. Residue labels are normalized to the
 #' monosaccharide and substituent vocabulary used by [glyrepr].
+#' A `-ol` suffix on the root residue is retained as alditol status.
 #'
 #' @param x A character vector of LINUCS strings. NA values are allowed and
 #'   will be returned as NA structures.
@@ -197,6 +198,7 @@ parse_linucs_residue <- function(x) {
   }
 
   anomer <- parse_linucs_anomer(x)
+  alditol <- stringr::str_ends(anomer$label, stringr::fixed("-ol"))
   normalized <- normalize_linucs_residue_label(anomer$label)
   stem_match <- match_linucs_mono_stem(normalized)
   mono <- unname(linucs_mono_stem_map()[[stem_match$stem]])
@@ -210,6 +212,7 @@ parse_linucs_residue <- function(x) {
     mono = mono,
     anomer = paste0(anomer$value, decide_anomer_pos(mono)),
     anomer_value = anomer$value,
+    alditol = alditol,
     sub = sub
   )
 }
@@ -554,7 +557,7 @@ build_linucs_graph <- function(root) {
 
   graph <- igraph::graph_from_data_frame(edge_df, vertices = vertex_df)
   graph$anomer <- root$residue$anomer
-  graph$alditol <- FALSE
+  graph$alditol <- isTRUE(root$residue$alditol)
   graph
 }
 
@@ -569,6 +572,11 @@ build_linucs_graph <- function(root) {
 add_linucs_mono_node <- function(node, state) {
   if (!identical(node$residue$kind, "mono")) {
     cli::cli_abort("Expected a LINUCS monosaccharide node.")
+  }
+  if (isTRUE(node$residue$alditol) && length(state$vertices) > 0L) {
+    cli::cli_abort(
+      "Only the root LINUCS residue can contain an alditol marker."
+    )
   }
 
   node_id <- length(state$vertices) + 1

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -3,8 +3,8 @@
 #' This function parses WURCS strings into a [glyrepr::glycan_structure()].
 #' Currently, only WURCS 2.0 is supported.
 #' For more information about WURCS, see [WURCS](https://github.com/glycoinfo/WURCS/wiki).
-#' Alditol residues are parsed as regular reducing-end glycans with unknown
-#' anomer configurations.
+#' Main reducing-end alditol residues retain their alditol status and use an
+#' unknown anomer configuration.
 #' Ambiguous alternative linkage groups are represented as floating glycan
 #' parts when their child residue or subtree is not localized to one parent.
 #' Floating substituents preserve their chemistry, carbon-position ambiguity,
@@ -558,14 +558,14 @@ is_wurcs_alditol_residue <- function(residue) {
 }
 
 
-#' Warn about alditol normalization in WURCS parsing.
+#' Warn about non-root alditol normalization in WURCS parsing.
 #'
 #' @return `NULL`, invisibly.
 #' @noRd
-warn_wurcs_alditol <- function() {
+warn_wurcs_non_root_alditol <- function() {
   cli::cli_warn(c(
-    "Alditol WURCS residues are parsed as regular reducing-end glycans with unknown anomer configurations.",
-    "i" = "For example, GlcNAc-ol is returned as GlcNAc(?1-."
+    "Only the main reducing-end WURCS residue can retain alditol status.",
+    "i" = "Non-root alditol residues are parsed as regular residues."
   ))
   invisible(NULL)
 }
@@ -880,7 +880,7 @@ parse_unique_residue_details <- function(x, residue_cache = NULL) {
   )
   list(
     values = lapply(details, `[[`, "value"),
-    has_alditol = any(vapply(details, `[[`, logical(1), "alditol"))
+    alditols = vapply(details, `[[`, logical(1), "alditol")
   )
 }
 
@@ -1115,7 +1115,11 @@ letter_to_int <- function(letter) {
 }
 
 
-prepare_graph_dfs <- function(residues, linkages) {
+prepare_graph_dfs <- function(
+  residues,
+  linkages,
+  alditols = rep(FALSE, length(residues))
+) {
   # Generate edgelist dataframe and vertex dataframe.
   # `edgelist_df`: "from", "to", "linkage".
   # `vertex_df`: "name", "mono", "anomer", "sub".
@@ -1124,6 +1128,7 @@ prepare_graph_dfs <- function(residues, linkages) {
     residues,
     ~ data.frame(as.list(.x))
   ))
+  vertex_df$alditol <- alditols
   if (length(linkages) == 0L) {
     edgelist_df <- data.frame(
       from = integer(),
@@ -1171,7 +1176,7 @@ build_glycan_graph <- function(
   ]
   core_anomer <- vertex_df$anomer[as.numeric(core_node)]
   graph$anomer <- core_anomer
-  graph$alditol <- FALSE # Not implemented yet
+  graph$alditol <- isTRUE(vertex_df$alditol[as.numeric(core_node)])
   graph
 }
 
@@ -1303,9 +1308,6 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
     residue_cache = residue_cache
   )
   unique_residues <- residue_details$values
-  if (residue_details$has_alditol) {
-    warn_wurcs_alditol()
-  }
 
   # residue_sequence: an integer vector of monosaccharide indices,
   # referring to the order of unique_residues, repeated monosaccharides allowed.
@@ -1313,6 +1315,7 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
   residue_sequence_part <- stringr::str_extract(x, wurcs_regex, group = 2)
   residue_sequence <- parse_residue_sequence(residue_sequence_part)
   residues <- unique_residues[residue_sequence]
+  alditols <- residue_details$alditols[residue_sequence]
 
   # linkages: a list of named lists, each list contains `from`, `to`, and `linkage`.
   # `from` and `to` are the indices of monosaccharides in the sequence.
@@ -1329,12 +1332,15 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
     floating_substituents <- linkage_data$floating_substituents
   }
 
-  graph_dfs <- prepare_graph_dfs(residues, linkages)
+  graph_dfs <- prepare_graph_dfs(residues, linkages, alditols = alditols)
   graph <- build_glycan_graph(
     graph_dfs$edgelist,
     graph_dfs$vertex,
     floating = floating,
     floating_substituents = floating_substituents
   )
+  if (any(alditols) && !isTRUE(graph$alditol)) {
+    warn_wurcs_non_root_alditol()
+  }
   graph
 }

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -1169,15 +1169,27 @@ build_glycan_graph <- function(
       floating_substituents
     )
   }
+  core_node <- find_wurcs_core_node(graph, floating)
+  core_anomer <- vertex_df$anomer[core_node]
+  graph$anomer <- core_anomer
+  graph$alditol <- isTRUE(vertex_df$alditol[core_node])
+  graph
+}
+
+
+#' Find the main reducing-end WURCS node
+#'
+#' @param graph A parsed WURCS graph.
+#' @param floating Parsed floating-part metadata.
+#'
+#' @return The numeric vertex index of the main reducing end.
+#' @noRd
+find_wurcs_core_node <- function(graph, floating = list()) {
   floating_roots <- purrr::map_int(floating, "root")
-  core_node <- igraph::V(graph)[
+  as.integer(igraph::V(graph)[
     igraph::degree(graph, mode = "in") == 0 &
       !seq_len(igraph::vcount(graph)) %in% floating_roots
-  ]
-  core_anomer <- vertex_df$anomer[as.numeric(core_node)]
-  graph$anomer <- core_anomer
-  graph$alditol <- isTRUE(vertex_df$alditol[as.numeric(core_node)])
-  graph
+  ])
 }
 
 
@@ -1339,7 +1351,8 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
     floating = floating,
     floating_substituents = floating_substituents
   )
-  if (any(alditols) && !isTRUE(graph$alditol)) {
+  core_node <- find_wurcs_core_node(graph, floating)
+  if (any(alditols[-core_node])) {
     warn_wurcs_non_root_alditol()
   }
   graph

--- a/man/parse_glycoct.Rd
+++ b/man/parse_glycoct.Rd
@@ -43,8 +43,8 @@ GlycoCT format consists of:
 the main glycan is unresolved
 }
 
-Alditol residues are parsed as regular reducing-end glycans with unknown
-anomer configurations.
+Main reducing-end alditol residues retain their alditol status and use an
+unknown anomer configuration.
 
 For more information about GlycoCT format, see the glycoct.md documentation.
 }

--- a/man/parse_iupac_compact.Rd
+++ b/man/parse_iupac_compact.Rd
@@ -37,8 +37,8 @@ and branches are written in parentheses. The parser normalizes compact
 notation into IUPAC-condensed notation, then uses the IUPAC-condensed parser
 to construct the glycan structure.
 
-Alditol glycans are parsed as regular reducing-end glycans with unknown
-anomer configurations.
+Alditol glycans marked with \code{+aldi} retain their alditol status and use an
+unknown reducing-end anomer configuration.
 }
 \examples{
 iupac <- "Mana1-3(Mana1-6)Manb1-4GlcNAcb"

--- a/man/parse_linucs.Rd
+++ b/man/parse_linucs.Rd
@@ -42,6 +42,7 @@ LINUCS linkages are written as \code{"(parent+child)"}, where \code{parent} is t
 linkage position on the parent residue and \code{child} is the anomeric linkage
 position on the child residue. Residue labels are normalized to the
 monosaccharide and substituent vocabulary used by \link[glyrepr:glyrepr-package]{glyrepr::glyrepr}.
+A \code{-ol} suffix on the root residue is retained as alditol status.
 }
 \examples{
 linucs <- "[][b-D-Glcp]{[(4+1)][b-D-Galp]{}}"

--- a/man/parse_wurcs.Rd
+++ b/man/parse_wurcs.Rd
@@ -34,8 +34,8 @@ A \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}} object.
 This function parses WURCS strings into a \code{\link[glyrepr:glycan_structure]{glyrepr::glycan_structure()}}.
 Currently, only WURCS 2.0 is supported.
 For more information about WURCS, see \href{https://github.com/glycoinfo/WURCS/wiki}{WURCS}.
-Alditol residues are parsed as regular reducing-end glycans with unknown
-anomer configurations.
+Main reducing-end alditol residues retain their alditol status and use an
+unknown anomer configuration.
 Ambiguous alternative linkage groups are represented as floating glycan
 parts when their child residue or subtree is not localized to one parent.
 Floating substituents preserve their chemistry, carbon-position ambiguity,

--- a/tests/testthat/test-auto-parse.R
+++ b/tests/testthat/test-auto-parse.R
@@ -5,6 +5,13 @@ test_that("auto_parse correctly identifies and parses IUPAC-condensed format", {
   expect_equal(as.character(result), as.character(expected))
 })
 
+test_that("auto_parse preserves inferred IUPAC-condensed alditols", {
+  result <- auto_parse("Glc-ol")
+
+  expect_identical(as.character(result), "Glc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(result)), TRUE)
+})
+
 test_that("auto_parse correctly identifies and parses IUPAC-short format", {
   input <- "Neu5Aca3Gala3(Fuca6)GlcNAcb-"
   result <- auto_parse(input)

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -39,19 +39,22 @@ test_that("GlycoCT preserves furanose ring bounds", {
 })
 
 test_that("GlycoCT preserves unusual configurations", {
-  expect_warning(
-    parsed <- parse_glycoct(c(
-      "RES\n1b:a-dgal-HEX-1:5|6:d",
-      "RES\n1b:b-lgul-HEX-1:5",
-      "RES\n1b:x-dido-HEX-1:5|6:a",
-      "RES\n1b:a-dgal-HEX-1:4|6:d",
-      "RES\n1b:o-dgal-HEX-0:0|1:aldi|6:d"
-    )),
-    "regular reducing-end glycans"
-  )
+  parsed <- parse_glycoct(c(
+    "RES\n1b:a-dgal-HEX-1:5|6:d",
+    "RES\n1b:b-lgul-HEX-1:5",
+    "RES\n1b:x-dido-HEX-1:5|6:a",
+    "RES\n1b:a-dgal-HEX-1:4|6:d",
+    "RES\n1b:o-dgal-HEX-0:0|1:aldi|6:d"
+  ))
   expect_identical(
     as.character(parsed),
-    c("D-Fuc(a1-", "L-Gul(b1-", "D-IdoA(?1-", "D-Fucf(a1-", "D-Fuc(?1-")
+    c(
+      "D-Fuc(a1-",
+      "L-Gul(b1-",
+      "D-IdoA(?1-",
+      "D-Fucf(a1-",
+      "D-Fuc-ol(?1-"
+    )
   )
 })
 
@@ -365,7 +368,7 @@ test_that("GlycoCT handles N-sulfated amino sugars with unknown ring bounds", {
   expect_equal(igraph::vertex_attr(graph, "sub"), "2S")
 })
 
-test_that("GlycoCT warns and uses unknown reducing-end anomers for alditols", {
+test_that("GlycoCT preserves alditols with unknown reducing-end anomers", {
   glcnac_alditol <- paste0(
     "RES\n",
     "1b:o-dglc-HEX-0:0|1:aldi\n",
@@ -373,11 +376,23 @@ test_that("GlycoCT warns and uses unknown reducing-end anomers for alditols", {
     "LIN\n",
     "1:1d(2+1)2n"
   )
-  expect_warning(
-    glcnac_structure <- parse_glycoct(glcnac_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
+  glcnac_structure <- parse_glycoct(glcnac_alditol)
+  expect_equal(as.character(glcnac_structure), "GlcNAc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(glcnac_structure)), TRUE)
+
+  unknown_ring_alditol <- paste0(
+    "RES\n",
+    "1b:x-dgal-HEX-x:x|1:aldi\n",
+    "2s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
   )
-  expect_equal(as.character(glcnac_structure), "GlcNAc(?1-")
+  unknown_ring_structure <- parse_glycoct(unknown_ring_alditol)
+  expect_equal(as.character(unknown_ring_structure), "GalNAc-ol(?1-")
+  expect_identical(
+    unname(glyrepr::get_alditol(unknown_ring_structure)),
+    TRUE
+  )
 
   linked_alditol <- paste0(
     "RES\n",
@@ -388,11 +403,9 @@ test_that("GlycoCT warns and uses unknown reducing-end anomers for alditols", {
     "1:1d(2+1)2n\n",
     "2:1o(4+1)3d"
   )
-  expect_warning(
-    linked_structure <- parse_glycoct(linked_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
-  )
-  expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc(?1-")
+  linked_structure <- parse_glycoct(linked_alditol)
+  expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(linked_structure)), TRUE)
 })
 
 test_that("GlycoCT parses all distinct converter alditol descriptors", {
@@ -547,15 +560,12 @@ test_that("GlycoCT parses all distinct converter alditol descriptors", {
 
   purrr::iwalk(alditol_mappings, function(mapping, mono_name) {
     glycoct <- create_glycoct_from_mapping(mapping)
-    expect_warning(
-      result <- parse_glycoct(glycoct),
-      "regular reducing-end glycans with unknown anomer configurations"
-    )
+    result <- parse_glycoct(glycoct)
     graph <- glyrepr::get_structure_graphs(result, return_list = FALSE)
 
     expect_equal(igraph::vertex_attr(graph, "mono"), mono_name)
     expect_equal(graph$anomer, paste0("?", glyrepr::get_anomer_pos(mono_name)))
-    expect_false(isTRUE(graph$alditol))
+    expect_identical(graph$alditol, TRUE)
   })
 
   # GlycanFormatConverter emits the same GlycoCT alditol descriptor for Ara-ol
@@ -880,7 +890,7 @@ test_that("GlycoCT warns for alditols inside UND sections", {
 
   expect_warning(
     result <- parse_glycoct(glycoct),
-    "regular reducing-end glycans with unknown anomer configurations"
+    "Only the main reducing-end GlycoCT residue"
   )
   expect_identical(unname(as.character(result)), "Glc(?1-3)Gal(a1-")
 })

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -408,6 +408,36 @@ test_that("GlycoCT preserves alditols with unknown reducing-end anomers", {
   expect_identical(unname(glyrepr::get_alditol(linked_structure)), TRUE)
 })
 
+test_that("GlycoCT warns when non-reducing alditols are normalized", {
+  non_reducing_alditol <- paste0(
+    "RES\n",
+    "1b:a-dgal-HEX-1:5\n",
+    "2b:o-dglc-HEX-0:0|1:aldi\n",
+    "LIN\n",
+    "1:1o(3+1)2d"
+  )
+  expect_warning(
+    structure <- parse_glycoct(non_reducing_alditol),
+    "Only the main reducing-end GlycoCT residue"
+  )
+  expect_identical(as.character(structure), "Glc(?1-3)Gal(a1-")
+  expect_identical(unname(glyrepr::get_alditol(structure)), FALSE)
+
+  root_and_non_reducing_alditols <- paste0(
+    "RES\n",
+    "1b:o-dglc-HEX-0:0|1:aldi\n",
+    "2b:o-dgal-HEX-0:0|1:aldi\n",
+    "LIN\n",
+    "1:1o(4+1)2d"
+  )
+  expect_warning(
+    structure <- parse_glycoct(root_and_non_reducing_alditols),
+    "Only the main reducing-end GlycoCT residue"
+  )
+  expect_identical(as.character(structure), "Gal(?1-4)Glc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(structure)), TRUE)
+})
+
 test_that("GlycoCT parses all distinct converter alditol descriptors", {
   alditol_mapping <- function(res, lin = NULL) {
     list(res = res, lin = lin)

--- a/tests/testthat/test-parse-iupac-compact.R
+++ b/tests/testthat/test-parse-iupac-compact.R
@@ -102,23 +102,22 @@ test_that("IUPAC-compact converts corpus modifier notation", {
   )
 })
 
-test_that("IUPAC-compact warns and parses alditols as regular reducing ends", {
+test_that("IUPAC-compact preserves alditols", {
   skip_on_old_win()
 
   simple_alditol <- "Fuca1-3(Galb1-4)Glc+aldi"
-  expect_warning(
-    simple_structure <- parse_iupac_compact(simple_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
+  simple_structure <- parse_iupac_compact(simple_alditol)
+  expect_equal(
+    as.character(simple_structure),
+    "Fuc(a1-3)[Gal(b1-4)]Glc-ol(?1-"
   )
-  expect_equal(as.character(simple_structure), "Fuc(a1-3)[Gal(b1-4)]Glc(?1-")
+  expect_identical(unname(glyrepr::get_alditol(simple_structure)), TRUE)
 
   linked_alditol <- "Galb1-3(Gal?1-?GlcNAcb1-3Galb1-4GlcNAcb1-6)GalNAc+aldi"
-  expect_warning(
-    linked_structure <- parse_iupac_compact(linked_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
-  )
+  linked_structure <- parse_iupac_compact(linked_alditol)
   expect_equal(
     as.character(linked_structure),
-    "Gal(?1-?)GlcNAc(b1-3)Gal(b1-4)GlcNAc(b1-6)[Gal(b1-3)]GalNAc(?1-"
+    "Gal(?1-?)GlcNAc(b1-3)Gal(b1-4)GlcNAc(b1-6)[Gal(b1-3)]GalNAc-ol(?1-"
   )
+  expect_identical(unname(glyrepr::get_alditol(linked_structure)), TRUE)
 })

--- a/tests/testthat/test-parse-iupac-condensed.R
+++ b/tests/testthat/test-parse-iupac-condensed.R
@@ -16,6 +16,13 @@ test_that("IUPAC-condensed preserves unusual configurations", {
   )
 })
 
+test_that("IUPAC-condensed preserves alditols", {
+  parsed <- parse_iupac_condensed("Gal(b1-4)GlcNAc-ol(a1-")
+
+  expect_identical(as.character(parsed), "Gal(b1-4)GlcNAc-ol(a1-")
+  expect_identical(unname(glyrepr::get_alditol(parsed)), TRUE)
+})
+
 test_that("IUPAC-condensed can drop generic glycans", {
   input <- c("Hex(??-", "Glc(?1-", "HexNAc(??-")
 

--- a/tests/testthat/test-parse-linucs.R
+++ b/tests/testthat/test-parse-linucs.R
@@ -17,7 +17,7 @@ linucs_parse_cases <- list(
   ),
   alditol_root = list(
     input = "[][D-Glc-ol]{[(?+1)][b-D-Galp]{}}",
-    expected = "Gal(b1-?)Glc(?1-"
+    expected = "Gal(b1-?)Glc-ol(?1-"
   ),
   nested_modifiers = list(
     input = "[][HexpNAc6S]{[(4+1)][HexpA2S]{[(4+1)][HexpNS3S]{[(4+1)][HexpA2S]{}}}}",
@@ -46,6 +46,12 @@ purrr::iwalk(linucs_parse_cases, function(case, case_name) {
     expect_s3_class(parsed, "glyrepr_structure")
     expect_identical(as.character(parsed), case$expected)
   })
+})
+
+test_that("LINUCS preserves root alditol status", {
+  parsed <- parse_linucs("[][D-Glc-ol]{[(?+1)][b-D-Galp]{}}")
+
+  expect_identical(unname(glyrepr::get_alditol(parsed)), TRUE)
 })
 
 test_that("LINUCS preserves NA and name semantics", {

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1207,20 +1207,16 @@ test_that("parse_residue handles alditol residues", {
 })
 
 
-test_that("parse_wurcs warns and uses unknown reducing-end anomers for alditols", {
+test_that("parse_wurcs preserves alditols with unknown reducing-end anomers", {
   glcnac_alditol <- "WURCS=2.0/1,1,0/[h2122h_2*NCC/3=O]/1/"
-  expect_warning(
-    glcnac_structure <- parse_wurcs(glcnac_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
-  )
-  expect_equal(as.character(glcnac_structure), "GlcNAc(?1-")
+  glcnac_structure <- parse_wurcs(glcnac_alditol)
+  expect_equal(as.character(glcnac_structure), "GlcNAc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(glcnac_structure)), TRUE)
 
   linked_alditol <- "WURCS=2.0/2,2,1/[h2122h_2*NCC/3=O][a2112h-1b_1-5]/1-2/a4-b1"
-  expect_warning(
-    linked_structure <- parse_wurcs(linked_alditol),
-    "regular reducing-end glycans with unknown anomer configurations"
-  )
-  expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc(?1-")
+  linked_structure <- parse_wurcs(linked_alditol)
+  expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(linked_structure)), TRUE)
 })
 
 

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -1220,6 +1220,26 @@ test_that("parse_wurcs preserves alditols with unknown reducing-end anomers", {
 })
 
 
+test_that("parse_wurcs warns when non-reducing alditols are normalized", {
+  non_reducing_alditol <- "WURCS=2.0/2,2,1/[a2122h-1a_1-5][h2112h]/1-2/a4-b1"
+  expect_warning(
+    structure <- parse_wurcs(non_reducing_alditol),
+    "Only the main reducing-end WURCS residue"
+  )
+  expect_identical(as.character(structure), "Gal(?1-4)Glc(a1-")
+  expect_identical(unname(glyrepr::get_alditol(structure)), FALSE)
+
+  root_and_non_reducing_alditols <-
+    "WURCS=2.0/2,2,1/[h2122h][h2112h]/1-2/a4-b1"
+  expect_warning(
+    structure <- parse_wurcs(root_and_non_reducing_alditols),
+    "Only the main reducing-end WURCS residue"
+  )
+  expect_identical(as.character(structure), "Gal(?1-4)Glc-ol(?1-")
+  expect_identical(unname(glyrepr::get_alditol(structure)), TRUE)
+})
+
+
 test_that("parse_wurcs correctly handles unknown linkages", {
   expect_equal(
     as.character(parse_wurcs(


### PR DESCRIPTION
## Summary

- Preserve graph-level alditol status when parsing GlycoCT, WURCS, IUPAC-compact, IUPAC-condensed, and LINUCS structures.
- Teach `auto_parse()` to recognize inferred IUPAC-condensed `-ol` syntax.
- Support GlycoCT alditol markers with unknown ring bounds while warning when non-root alditols cannot be represented losslessly.

## Verification

- `devtools::test()`: 1,600 passed.
- `pkgdown::check_pkgdown()`: no problems.
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings; one environment-only clock note.
- All 3,814 shared alditol records in the docs corpus produced matching canonical graphs across IUPAC-compact, GlycoCT, and WURCS.
- Verified representative round-trips with GlycanFormatConverter CLI 2.10.3.
