### PR TITLE
Fix remaining GlycoCT and WURCS corpus parser bugs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glyparse (development version)
 
+* `parse_glycoct()` now preserves repeated and alternative-position substituents, distinguishes N-acetyl and N-glycolyl from acetyl, maps generic `HexA` and `HexN` residues, and rejects unrepresentable non-alditol open-chain residues explicitly. (#47)
+* `parse_wurcs()` now accepts direct phosphate and alternative-position substituent encodings, preserves generic-root anomer positions, and orients ambiguous linkages using alditol-aware donor semantics. (#47)
 * `parse_glycoct()` and `parse_wurcs()` now preserve declared floating candidate-parent domains in global floating-parent structures: GlycoCT UND parents remain restricted to the main graph, while WURCS parents may target other floating components.
 * `parse_glycoct()`, `parse_wurcs()`, `parse_iupac_compact()`, `parse_iupac_condensed()`, `parse_linucs()`, and `auto_parse()` now preserve alditol reducing ends in parsed structures. (#46)
 * `parse_glycoct()` and `parse_wurcs()` now preserve floating substituents with unresolved parent residues, including their chemistry, carbon positions, and candidate parents. (#45)

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -2228,13 +2228,20 @@ match_generic_glycoct_composite <- function(group, residues, linkages) {
       "amino" %in% group_subs &&
       has_glycoct_substituent_at(group, residues, linkages, "amino", "2")
   ) {
-    extra_subs <- group_subs
-    extra_subs <- extra_subs[-match("amino", extra_subs)]
-    extra_sub <- format_extra_substituents(
-      extra_subs,
+    substituent_tokens <- glycoct_substituent_tokens(
       group,
       residues,
       linkages
+    )
+    identity_index <- purrr::detect_index(
+      substituent_tokens,
+      function(token) {
+        parts <- stringr::str_split_1(token, stringr::fixed("\r"))
+        identical(parts[[1]], "amino") && identical(parts[[2]], "2")
+      }
+    )
+    extra_sub <- format_glycoct_substituent_tokens(
+      substituent_tokens[-identity_index]
     )
     return(list(mono = "HexN", sub = extra_sub))
   }

--- a/R/parse-glycoct.R
+++ b/R/parse-glycoct.R
@@ -1040,7 +1040,13 @@ format_glycoct_reducing_anomer <- function(reducing_end) {
   if (is.null(anomer_pos) || is.na(anomer_pos)) {
     anomer_pos <- decide_anomer_pos(reducing_end$mono)
   } else if (anomer_pos == "x") {
-    anomer_pos <- "?"
+    anomer_pos <- if (
+      reducing_end$mono %in% glyrepr::available_monosaccharides("generic")
+    ) {
+      decide_anomer_pos(reducing_end$mono)
+    } else {
+      "?"
+    }
   }
 
   paste0(anomer_config, anomer_pos)
@@ -1643,12 +1649,23 @@ compile_glycoct_mapping <- function(name, mapping) {
     pattern_linkages <- pattern_linkages[!is.na(pattern_linkages)]
   }
 
+  mapping_residues <- parse_res_section(mapping$res)
+  mapping_linkages <- parse_lin_section(
+    if (is.null(mapping$lin)) character() else mapping$lin
+  )
+  pattern_substituents <- glycoct_substituent_tokens(
+    as.integer(names(mapping_residues)),
+    mapping_residues,
+    mapping_linkages
+  )
+
   c(
     list(name = name),
     glycoct_mono_signature(pattern_mono),
     list(
       subs = pattern_subs,
       linkages = pattern_linkages,
+      substituents = sort(pattern_substituents),
       single = length(mapping$res) == 1L
     )
   )
@@ -1682,13 +1699,25 @@ glycoct_signature_mono_matches <- function(signature, entry) {
     same_ring_family
 }
 
-glycoct_signature_key <- function(core, subs, linkages) {
+glycoct_signature_key <- function(core, substituents) {
   paste(
     core,
-    paste(subs, collapse = "\r"),
-    paste(linkages, collapse = "\r"),
+    paste(substituents, collapse = "\r"),
     sep = "\n"
   )
+}
+
+glycoct_signature_substituents <- function(signature) {
+  if (!is.null(signature$substituents)) {
+    return(signature$substituents)
+  }
+  if (length(signature$subs) != length(signature$linkages)) {
+    return(character())
+  }
+  purrr::map2_chr(signature$subs, signature$linkages, function(sub, linkage) {
+    positions <- stringr::str_split_1(linkage, stringr::fixed("+"))
+    paste(sub, positions[[1]], positions[[2]], sep = "\r")
+  })
 }
 
 compile_glycoct_mapping_index <- function(mappings) {
@@ -1703,8 +1732,7 @@ compile_glycoct_mapping_index <- function(mappings) {
     function(entry) {
       glycoct_signature_key(
         entry$core,
-        entry$subs,
-        entry$linkages
+        entry$substituents
       )
     },
     character(1)
@@ -1790,9 +1818,37 @@ glycoct_group_signature <- function(group, residues, linkages) {
     mono_signature,
     list(
       subs = sort(group_subs),
-      linkages = sort(group_linkages)
+      linkages = sort(group_linkages),
+      substituents = sort(glycoct_substituent_tokens(
+        group,
+        residues,
+        linkages
+      ))
     )
   )
+}
+
+glycoct_substituent_tokens <- function(group, residues, linkages) {
+  tokens <- character()
+  for (linkage in linkages) {
+    from_res <- residues[[as.character(linkage$from_res)]]
+    to_res <- residues[[as.character(linkage$to_res)]]
+    if (
+      linkage$from_res %in%
+        group &&
+        linkage$to_res %in% group &&
+        !is.null(from_res) &&
+        !is.null(to_res) &&
+        identical(from_res$type, "mono") &&
+        identical(to_res$type, "sub")
+    ) {
+      tokens <- c(
+        tokens,
+        paste(to_res$content, linkage$from_pos, linkage$to_pos, sep = "\r")
+      )
+    }
+  }
+  tokens
 }
 
 consolidate_residues <- function(residues, linkages, mono_mapping_index) {
@@ -1963,8 +2019,7 @@ match_composite_structure <- function(
 
   key <- glycoct_signature_key(
     group_signature$core,
-    group_signature$subs,
-    group_signature$linkages
+    glycoct_signature_substituents(group_signature)
   )
   candidates <- mapping_index$exact[[key]]
   if (is.null(candidates)) {
@@ -1995,7 +2050,8 @@ match_partial_composite_structure <- function(
 
   # Try to find the best partial match and identify extra substituents
   best_match <- NULL
-  best_extra_subs <- c()
+  best_extra_substituents <- character()
+  group_substituents <- group_signature$substituents
   group_subs <- group_signature$subs
   group_mono <- group_signature$mono
 
@@ -2010,33 +2066,35 @@ match_partial_composite_structure <- function(
   # Try to find a known composite that uses a subset of our substituents
   for (idx in candidate_indices) {
     entry <- mapping_index$entries[[idx]]
-    pattern_subs <- entry$subs
+    pattern_substituents <- entry$substituents
 
     # Check if pattern substituents are a subset of group substituents
-    if (length(pattern_subs) > 0 && all(pattern_subs %in% group_subs)) {
+    extra_substituents <- glycoct_multiset_difference(
+      group_substituents,
+      pattern_substituents
+    )
+    if (length(pattern_substituents) > 0 && !is.null(extra_substituents)) {
       if (
         !is.null(group_mono) &&
           glycoct_signature_mono_matches(group_signature, entry)
       ) {
-        exact_match <- identical(pattern_subs, group_signature$subs) &&
-          identical(entry$linkages, group_signature$linkages)
+        exact_match <- length(extra_substituents) == 0L
         if (exact_match) {
           next
         }
 
         # For partial matching, only consider if there are extra substituents
-        if (length(pattern_subs) < length(group_subs)) {
-          extra_subs <- setdiff(group_subs, pattern_subs)
-
+        if (length(pattern_substituents) < length(group_substituents)) {
           if (
             is.null(best_match) ||
-              length(pattern_subs) > length(best_match$pattern_subs)
+              length(pattern_substituents) >
+                length(best_match$pattern_substituents)
           ) {
             best_match <- list(
               mono_name = entry$name,
-              pattern_subs = pattern_subs
+              pattern_substituents = pattern_substituents
             )
-            best_extra_subs <- extra_subs
+            best_extra_substituents <- extra_substituents
           }
         }
       }
@@ -2045,11 +2103,8 @@ match_partial_composite_structure <- function(
 
   if (!is.null(best_match)) {
     # Format extra substituents with position information
-    formatted_extra_subs <- format_extra_substituents(
-      best_extra_subs,
-      group,
-      residues,
-      linkages
+    formatted_extra_subs <- format_glycoct_substituent_tokens(
+      best_extra_substituents
     )
 
     return(list(
@@ -2074,6 +2129,49 @@ match_partial_composite_structure <- function(
   }
 
   return(list(mono = "Unk", sub = ""))
+}
+
+glycoct_multiset_difference <- function(x, y) {
+  remaining <- x
+  for (value in y) {
+    index <- match(value, remaining)
+    if (is.na(index)) {
+      return(NULL)
+    }
+    remaining <- remaining[-index]
+  }
+  remaining
+}
+
+format_glycoct_substituent_tokens <- function(tokens) {
+  if (length(tokens) == 0L) {
+    return("")
+  }
+  formatted <- purrr::map_chr(tokens, function(token) {
+    parts <- stringr::str_split_1(token, stringr::fixed("\r"))
+    position <- parts[[2]]
+    if (position == "-1") {
+      position <- "?"
+    }
+    position <- stringr::str_replace_all(position, "\\|", "/")
+    paste0(position, glycoct_substituent_abbreviation(parts[[1]]))
+  })
+  formatted <- sort_glycoct_substituents(formatted)
+  paste(formatted, collapse = ",")
+}
+
+sort_glycoct_substituents <- function(substituents) {
+  if (length(substituents) == 0L) {
+    return(character())
+  }
+  positions <- stringr::str_extract(substituents, "^[?0-9/]+")
+  first_position <- purrr::map_dbl(positions, function(position) {
+    if (is.na(position) || position == "?") {
+      return(Inf)
+    }
+    min(as.numeric(stringr::str_split_1(position, stringr::fixed("/"))))
+  })
+  substituents[order(first_position, substituents)]
 }
 
 #' Match generic GlycoCT monosaccharide composites
@@ -2122,6 +2220,23 @@ match_generic_glycoct_composite <- function(group, residues, linkages) {
       sub <- paste(c("2S", extra_sub[extra_sub != ""]), collapse = ",")
       return(list(mono = amino_mono, sub = sub))
     }
+  }
+
+  if (
+    is_generic_glycoct_hex(group_mono$content) &&
+      !is_generic_glycoct_dhex(group_mono$content) &&
+      "amino" %in% group_subs &&
+      has_glycoct_substituent_at(group, residues, linkages, "amino", "2")
+  ) {
+    extra_subs <- group_subs
+    extra_subs <- extra_subs[-match("amino", extra_subs)]
+    extra_sub <- format_extra_substituents(
+      extra_subs,
+      group,
+      residues,
+      linkages
+    )
+    return(list(mono = "HexN", sub = extra_sub))
   }
 
   if (
@@ -2270,13 +2385,14 @@ has_glycoct_substituent_at <- function(
 format_extra_substituents <- function(extra_subs, group, residues, linkages) {
   # Format substituents with position information (e.g., "6S" for sulfate at position 6)
   formatted <- c()
+  used_substituents <- integer()
 
   for (sub_content in extra_subs) {
     # Find the position of this substituent
     position <- "?"
 
     for (linkage in linkages) {
-      if (linkage$to_res %in% group) {
+      if (linkage$to_res %in% group && !linkage$to_res %in% used_substituents) {
         to_res <- residues[[as.character(linkage$to_res)]]
         if (
           !is.null(to_res) &&
@@ -2284,6 +2400,7 @@ format_extra_substituents <- function(extra_subs, group, residues, linkages) {
             to_res$content == sub_content
         ) {
           position <- as.character(linkage$from_pos)
+          used_substituents <- c(used_substituents, linkage$to_res)
           break
         }
       }
@@ -2293,6 +2410,7 @@ format_extra_substituents <- function(extra_subs, group, residues, linkages) {
     if (position == "-1") {
       position <- "?"
     }
+    position <- stringr::str_replace_all(position, "\\|", "/")
 
     # Format the substituent with position
     formatted <- c(
@@ -2302,6 +2420,7 @@ format_extra_substituents <- function(extra_subs, group, residues, linkages) {
   }
 
   # Join multiple substituents
+  formatted <- sort_glycoct_substituents(formatted)
   paste(formatted, collapse = ",")
 }
 
@@ -2309,7 +2428,8 @@ glycoct_substituent_abbreviation <- function(x) {
   switch(
     x,
     sulfate = "S",
-    `n-acetyl` = "Ac",
+    `n-acetyl` = "NAc",
+    `n-glycolyl` = "NGc",
     acetyl = "Ac",
     methyl = "Me",
     amino = "N",
@@ -2412,6 +2532,14 @@ map_single_mono_ringless <- function(content) {
   # Extract monosaccharide name from content like "dglc-HEX-1:5" or "lgal-HEX-1:5|6:d"
 
   is_alditol <- is_glycoct_alditol_mono(content)
+  if (
+    identical(extract_glycoct_ring_bounds(content), "0:0") &&
+      !is_alditol
+  ) {
+    cli::cli_abort(
+      "Open-chain GlycoCT residues without an alditol modification are not representable."
+    )
+  }
   mapping_index <- glycoct_mapping_index(alditol = is_alditol)
   mono_signature <- glycoct_mono_signature(content)
   candidates <- mapping_index$by_core[[mono_signature$core]]
@@ -2433,6 +2561,9 @@ map_single_mono_ringless <- function(content) {
 
   if (is_generic_glycoct_dhex(content)) {
     return("dHex")
+  }
+  if (is_generic_glycoct_hexa(content)) {
+    return("HexA")
   }
   if (is_generic_glycoct_hex(content)) {
     return("Hex")
@@ -2529,6 +2660,19 @@ is_generic_glycoct_dhex <- function(content) {
   isTRUE(stringr::str_detect(
     content,
     "^HEX-(?:\\d+|x):(?:\\d+|x)\\|6:d$"
+  ))
+}
+
+#' Check whether a GlycoCT content string is a generic hexuronic acid
+#'
+#' @param content GlycoCT monosaccharide content without the leading anomer.
+#'
+#' @return A logical scalar.
+#' @noRd
+is_generic_glycoct_hexa <- function(content) {
+  isTRUE(stringr::str_detect(
+    content,
+    "^HEX-(?:\\d+|x):(?:\\d+|x)\\|6:a$"
   ))
 }
 

--- a/R/parse-wurcs.R
+++ b/R/parse-wurcs.R
@@ -497,7 +497,7 @@ WURCS_SUB_REGEX <- c(
   "Me" = "OC",
   "Ac" = "OCC/3=O",
   "NAc" = "NCC/3=O",
-  "P" = "OPO/3O/3=O",
+  "P" = "(?:OPO/3O/3=O|PO/2O/2=O)",
   "S" = "OSO/3=O/3=O",
   "Pyr" = "OCCC/4=O/3=O",
   "PC" = "OP(\\^X)?OCCNC/7C/7C/3O/3=O",
@@ -687,7 +687,11 @@ parse_residue_details <- function(residue) {
         }
         mono <- names(WURCS_AMBIGUOUS_MONO_REGEX)[[ambiguous_mono_idx]]
         mono_pattern <- WURCS_AMBIGUOUS_MONO_REGEX[[ambiguous_mono_idx]]
-        anomer <- "??"
+        anomer <- if (mono %in% c("Hex", "HexNAc", "HexN")) {
+          paste0("?", wurcs_anomer_pos(mono))
+        } else {
+          "??"
+        }
       }
     }
   } else {
@@ -790,7 +794,9 @@ parse_residue_details <- function(residue) {
       # Add back the leading "_" for pattern matching
       sub_part_with_underscore <- paste0("_", sub_part)
 
-      sub_patterns <- stringr::str_glue("^_(\\d+|\\?)\\*{WURCS_SUB_REGEX}$")
+      sub_patterns <- stringr::str_glue(
+        "^_((?:\\d+(?:\\|\\d+)*)|\\?)\\*{WURCS_SUB_REGEX}$"
+      )
       sub_idx <- purrr::detect_index(
         sub_patterns,
         ~ stringr::str_detect(sub_part_with_underscore, .x)
@@ -803,9 +809,10 @@ parse_residue_details <- function(residue) {
       sub_name <- names(WURCS_SUB_REGEX)[[sub_idx]]
       sub_pos <- stringr::str_extract(
         sub_part_with_underscore,
-        "_(\\d+|\\?)",
+        "_((?:\\d+(?:\\|\\d+)*)|\\?)",
         group = 1
       )
+      sub_pos <- stringr::str_replace_all(sub_pos, "\\|", "/")
       paste0(sub_pos, sub_name)
     })
 
@@ -910,7 +917,11 @@ parse_linkages <- function(x) {
 }
 
 
-parse_wurcs_linkages <- function(x, residues) {
+parse_wurcs_linkages <- function(
+  x,
+  residues,
+  alditols = rep(FALSE, length(residues))
+) {
   linkages <- stringr::str_split_1(x, "_")
   is_floating <- stringr::str_detect(linkages, stringr::fixed("}"))
   floating <- purrr::map(
@@ -923,7 +934,8 @@ parse_wurcs_linkages <- function(x, residues) {
     ordinary = purrr::map(
       linkages[!is_floating],
       parse_one_linkage,
-      anomers = purrr::map_chr(residues, "anomer")
+      anomers = purrr::map_chr(residues, "anomer"),
+      alditols = alditols
     ),
     floating = purrr::map(
       floating[floating_types == "part"],
@@ -1049,7 +1061,7 @@ parse_wurcs_linkage_endpoint <- function(x) {
 }
 
 
-parse_one_linkage <- function(x, anomers = NULL) {
+parse_one_linkage <- function(x, anomers = NULL, alditols = NULL) {
   # Input: a string of one WURCS linkage, e.g. "a4-b1"
   # Output: a named list of `from`, `to`, and `linkage`
   spl <- stringr::str_split_1(x, "-")
@@ -1059,8 +1071,16 @@ parse_one_linkage <- function(x, anomers = NULL) {
       stringr::fixed("|")
     )
   } else {
-    left_donor <- wurcs_endpoint_can_be_donor(spl[[1]], anomers)
-    right_donor <- wurcs_endpoint_can_be_donor(spl[[2]], anomers)
+    left_donor <- wurcs_endpoint_can_be_donor(
+      spl[[1]],
+      anomers,
+      alditols
+    )
+    right_donor <- wurcs_endpoint_can_be_donor(
+      spl[[2]],
+      anomers,
+      alditols
+    )
     swap_endpoints <- left_donor &&
       !right_donor ||
       !left_donor &&
@@ -1076,7 +1096,11 @@ parse_one_linkage <- function(x, anomers = NULL) {
       parts <- stringr::str_split_1(part, stringr::fixed("|"))
       pos <- stringr::str_sub(parts, 2, -1)
       idx_part <- stringr::str_sub(part, 1, 1)
-      pos_part <- stringr::str_c(pos, collapse = "/")
+      pos_part <- if ("?" %in% pos) {
+        "?"
+      } else {
+        stringr::str_c(pos, collapse = "/")
+      }
       stringr::str_c(idx_part, pos_part)
     } else {
       part
@@ -1097,13 +1121,17 @@ parse_one_linkage <- function(x, anomers = NULL) {
 }
 
 
-wurcs_endpoint_can_be_donor <- function(endpoint, anomers) {
+wurcs_endpoint_can_be_donor <- function(endpoint, anomers, alditols = NULL) {
   alternatives <- stringr::str_split_1(endpoint, stringr::fixed("|"))
   node <- letter_to_int(stringr::str_sub(alternatives[[1]], 1, 1))
+  if (!is.null(alditols) && isTRUE(alditols[[node]])) {
+    return(FALSE)
+  }
   positions <- stringr::str_sub(alternatives, 2, -1)
   anomer_position <- stringr::str_sub(anomers[[node]], 2, -1)
 
-  any(positions == "?" | positions == anomer_position)
+  any(anomer_position != "?" & positions == anomer_position) ||
+    all(positions == "?")
 }
 
 letter_to_int <- function(letter) {
@@ -1321,7 +1349,11 @@ do_parse_wurcs <- function(x, residue_cache = NULL) {
     floating <- list()
     floating_substituents <- list()
   } else {
-    linkage_data <- parse_wurcs_linkages(linkage_part, residues)
+    linkage_data <- parse_wurcs_linkages(
+      linkage_part,
+      residues,
+      alditols = alditols
+    )
     linkages <- linkage_data$ordinary
     floating <- linkage_data$floating
     floating_substituents <- linkage_data$floating_substituents

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -106,7 +106,27 @@ test_that("GlycoCT maps generic HEX descriptors", {
     "LIN\n",
     "1:1d(2+1)2n"
   )
+  hexn_4n <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:amino\n",
+    "3s:amino\n",
+    "LIN\n",
+    "1:1d(2+1)2n\n",
+    "2:1d(4+1)3n"
+  )
+  hexn_4n_reversed <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:amino\n",
+    "3s:amino\n",
+    "LIN\n",
+    "1:1d(4+1)2n\n",
+    "2:1d(2+1)3n"
+  )
   expect_equal(as.character(parse_glycoct(hexn)), "HexN(?1-")
+  expect_equal(as.character(parse_glycoct(hexn_4n)), "HexN4N(?1-")
+  expect_equal(as.character(parse_glycoct(hexn_4n_reversed)), "HexN4N(?1-")
   expect_equal(as.character(parse_glycoct(hexnac)), "HexNAc(?1-")
   expect_equal(as.character(parse_glycoct(hexnac_6s)), "HexNAc6S(?1-")
 })

--- a/tests/testthat/test-parse-glycoct.R
+++ b/tests/testthat/test-parse-glycoct.R
@@ -75,8 +75,13 @@ test_that("GlycoCT accepts space-separated records", {
 })
 
 test_that("GlycoCT maps generic HEX descriptors", {
-  expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-x:x")), "Hex(??-")
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-x:x")), "Hex(?1-")
   expect_equal(as.character(parse_glycoct("RES\n1b:x-HEX-1:x|6:d")), "dHex(?1-")
+
+  expect_equal(
+    as.character(parse_glycoct("RES\n1b:x-HEX-1:5|6:a")),
+    "HexA(?1-"
+  )
 
   hexnac <- paste0(
     "RES\n",
@@ -94,12 +99,20 @@ test_that("GlycoCT maps generic HEX descriptors", {
     "1:1d(2+1)2n\n",
     "2:1o(6+1)3n"
   )
+  hexn <- paste0(
+    "RES\n",
+    "1b:x-HEX-1:x\n",
+    "2s:amino\n",
+    "LIN\n",
+    "1:1d(2+1)2n"
+  )
+  expect_equal(as.character(parse_glycoct(hexn)), "HexN(?1-")
   expect_equal(as.character(parse_glycoct(hexnac)), "HexNAc(?1-")
   expect_equal(as.character(parse_glycoct(hexnac_6s)), "HexNAc6S(?1-")
 })
 
 test_that("GlycoCT maps generic PEN descriptors", {
-  expect_equal(as.character(parse_glycoct("RES\n1b:x-PEN-x:x")), "Pen(??-")
+  expect_equal(as.character(parse_glycoct("RES\n1b:x-PEN-x:x")), "Pen(?1-")
   expect_equal(as.character(parse_glycoct("RES\n1b:x-PEN-1:4")), "Pen(?1-")
 })
 
@@ -281,7 +294,7 @@ test_that("GlycoCT substituents", {
   sub_Me <- "RES\n1b:a-dglc-HEX-1:5\n2s:acetyl\nLIN\n1:1o(3+1)2n\n"
   expect_sub_equal(sub_Me, "3Ac")
   sub_NAc <- "RES\n1b:a-dglc-HEX-1:5\n2s:n-acetyl\nLIN\n1:1d(3+1)2n\n"
-  expect_sub_equal(sub_NAc, "3Ac")
+  expect_sub_equal(sub_NAc, "3NAc")
   sub_P <- "RES\n1b:a-dglc-HEX-1:5\n2s:phosphate\nLIN\n1:1o(3+1)2n\n"
   expect_sub_equal(sub_P, "3P")
   sub_S <- "RES\n1b:a-dglc-HEX-1:5\n2s:sulfate\nLIN\n1:1o(3+1)2n\n"
@@ -290,6 +303,58 @@ test_that("GlycoCT substituents", {
   expect_sub_equal(sub_PPEtn, "3PPEtn")
   sub_PEtn <- "RES\n1b:a-dglc-HEX-1:5\n2s:phospho-ethanolamine\nLIN\n1:1o(3+1)2n\n"
   expect_sub_equal(sub_PEtn, "3PEtn")
+})
+
+test_that("GlycoCT keeps repeated and alternative substituent positions", {
+  repeated_sulfate <- paste0(
+    "RES\n",
+    "1b:x-dglc-HEX-1:5\n",
+    "2s:sulfate\n",
+    "3s:sulfate\n",
+    "LIN\n",
+    "1:1o(3+1)2n\n",
+    "2:1o(6+1)3n"
+  )
+  alternative_sulfate <- paste0(
+    "RES\n",
+    "1b:x-dglc-HEX-1:5\n",
+    "2s:sulfate\n",
+    "LIN\n",
+    "1:1o(3|4+1)2n"
+  )
+  neu5ac_1n <- paste0(
+    "RES\n",
+    "1b:a-dgro-dgal-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:amino\n",
+    "3s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(1+1)2n\n",
+    "2:1d(5+1)3n"
+  )
+  neu5ac_9nac <- paste0(
+    "RES\n",
+    "1b:a-dgro-dgal-NON-2:6|1:a|2:keto|3:d\n",
+    "2s:n-acetyl\n",
+    "3s:n-acetyl\n",
+    "LIN\n",
+    "1:1d(5+1)2n\n",
+    "2:1d(9+1)3n"
+  )
+
+  expect_equal(as.character(parse_glycoct(repeated_sulfate)), "Glc3S6S(?1-")
+  expect_equal(
+    as.character(parse_glycoct(alternative_sulfate)),
+    "Glc3/4S(?1-"
+  )
+  expect_equal(as.character(parse_glycoct(neu5ac_1n)), "Neu5Ac1N(a2-")
+  expect_equal(as.character(parse_glycoct(neu5ac_9nac)), "Neu5Ac9NAc(a2-")
+})
+
+test_that("GlycoCT rejects unrepresentable open-chain residues explicitly", {
+  expect_error(
+    map_single_mono_ringless("dglc-HEX-0:0"),
+    "Open-chain GlycoCT residues without an alditol modification"
+  )
 })
 
 test_that("GlycoCT: GlcA3S(?1-?)Gal(?1-?)GlcNAc(?1-, (Unknown linkages and anomers)", {

--- a/tests/testthat/test-parse-wurcs.R
+++ b/tests/testthat/test-parse-wurcs.R
@@ -417,6 +417,10 @@ test_that("parse_residue recognizes substituents on Glc", {
     c(mono = "Glc", anomer = "a1", sub = "3P")
   )
   expect_equal(
+    parse_residue("a2122h-1a_1-5_3*PO/2O/2=O"),
+    c(mono = "Glc", anomer = "a1", sub = "3P")
+  )
+  expect_equal(
     parse_residue("a2122h-1a_1-5_3*OSO/3=O/3=O"),
     c(mono = "Glc", anomer = "a1", sub = "3S")
   )
@@ -475,6 +479,10 @@ test_that("parse_residue recognized substituents with known positions", {
   expect_equal(
     parse_residue("a2122h-1a_1-5_2*NCC/3=O_?*OC"),
     c(mono = "GlcNAc", anomer = "a1", sub = "?Me")
+  )
+  expect_equal(
+    parse_residue("a2112h-1b_1-5_2*NCC/3=O_3|4*OSO/3=O/3=O"),
+    c(mono = "GalNAc", anomer = "b1", sub = "3/4S")
   )
 })
 
@@ -726,6 +734,14 @@ test_that("parse_residue maps generic WURCS descriptors to generic monosaccharid
   expect_equal(
     parse_residue("uxxxxm"),
     c(mono = "dHex", anomer = "??", sub = "")
+  )
+  expect_equal(
+    parse_residue("uxxxxh"),
+    c(mono = "Hex", anomer = "?1", sub = "")
+  )
+  expect_equal(
+    parse_residue("uxxxxh_2*N"),
+    c(mono = "HexN", anomer = "?1", sub = "")
   )
   expect_equal(
     parse_residue("u2112m"),
@@ -1217,6 +1233,64 @@ test_that("parse_wurcs preserves alditols with unknown reducing-end anomers", {
   linked_structure <- parse_wurcs(linked_alditol)
   expect_equal(as.character(linked_structure), "Gal(b1-4)GlcNAc-ol(?1-")
   expect_identical(unname(glyrepr::get_alditol(linked_structure)), TRUE)
+})
+
+test_that("parse_wurcs orients linkages away from reducing-end alditols", {
+  wurcs <- paste0(
+    "WURCS=2.0/2,2,1/",
+    "[a2112h-1b_1-5][h2122h_2*NCC/3=O]/",
+    "1-2/a1-b6"
+  )
+
+  expect_equal(
+    as.character(parse_wurcs(wurcs)),
+    "Gal(b1-6)GlcNAc-ol(?1-"
+  )
+})
+
+test_that("parse_wurcs collapses mixed known and unknown linkage positions", {
+  expect_equal(
+    parse_one_linkage(
+      "b4|b?-c1",
+      anomers = c("?1", "?1", "b1"),
+      alditols = rep(FALSE, 3)
+    ),
+    list(from = 2, to = 3, linkage = "1-?")
+  )
+})
+
+test_that("WURCS corpus substituent encodings remain parseable", {
+  direct_phosphate <- paste0(
+    "WURCS=2.0/4,9,8/",
+    "[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5]",
+    "[a1122h-1a_1-5][a1122h-1a_1-5_6*PO/2O/2=O]/",
+    "1-1-2-3-3-3-3-3-4/",
+    "a4-b1_b4-c1_c3-d1_c6-f1_d2-e1_f3-g1_f6-h1_h2-i1"
+  )
+  alternative_sulfate <- paste0(
+    "WURCS=2.0/4,9,8/",
+    "[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5]",
+    "[a1122h-1a_1-5]",
+    "[a2112h-1b_1-5_2*NCC/3=O_3|4*OSO/3=O/3=O]/",
+    "1-1-2-3-1-4-3-3-3/",
+    "a4-b1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g3-h1_g6-i1"
+  )
+
+  expect_equal(
+    as.character(parse_wurcs(direct_phosphate)),
+    paste0(
+      "Man6P(a1-2)Man(a1-6)[Man(a1-3)]Man(a1-6)",
+      "[Man(a1-2)Man(a1-3)]Man(b1-4)GlcNAc(b1-4)GlcNAc(b1-"
+    )
+  )
+  expect_equal(
+    as.character(parse_wurcs(alternative_sulfate)),
+    paste0(
+      "GalNAc3/4S(b1-4)GlcNAc(b1-2)Man(a1-3)",
+      "[Man(a1-3)[Man(a1-6)]Man(a1-6)]Man(b1-4)",
+      "GlcNAc(b1-4)GlcNAc(b1-"
+    )
+  )
 })
 
 


### PR DESCRIPTION
## Summary

This PR resolves the remaining losslessly representable parser defects identified by the GlycoCT, WURCS, and GLYCAM corpus audits. Revalidation against the current glyrepr and glyparse sources covers all 1,410 rows presently labeled `glyparse_bug`: 1,321 now parse with the intended semantics, while the remaining 89 are confirmed representation restrictions rather than glyparse defects.

### GlycoCT fixes

- Couple substituent identity with its parent and child linkage positions during composite matching, preventing false matches when independently sorted substituent and position lists happen to agree.
- Preserve repeated substituents as a multiset, so sulfates at positions such as 3 and 6 no longer reuse the first matching residue position.
- Preserve alternative substituent positions such as `3|4` as glyrepr's `3/4` notation.
- Distinguish `n-acetyl` and `n-glycolyl` from ordinary acetyl substituents, preserving forms such as `Neu5Ac9NAc` and unknown-position `NAc`.
- Preserve explicit position-1 amino substituents on `Neu5Ac`.
- Map generic `HEX|6:a` and position-2 amino `HEX` descriptors to `HexA` and `HexN`.
- Use the supported default anomer position for representable generic reducing-end residues.
- Reject non-alditol open-chain `0:0` residues explicitly instead of producing malformed `?0` IUPAC output.

### WURCS fixes

- Accept direct phosphate encodings such as `PO/2O/2=O` in addition to `OPO/3O/3=O`.
- Accept alternative substituent positions such as `_3|4*OSO/3=O/3=O` and normalize them to `3/4S`.
- Preserve supported anomer positions for ambiguous generic `Hex`, `HexNAc`, and `HexN` roots.
- Use alditol metadata when determining linkage donor orientation, preventing reducing-end alditols from being treated as donors.
- Collapse mixed known/unknown linkage alternatives such as `4|?` to an unknown position instead of generating invalid `4/?` linkages.
- Avoid treating mixed unknown-position endpoints as donors solely because one alternative contains `?`.

### Corpus adjudication

The 89 rows that remain unparsable require information glyrepr cannot currently encode losslessly: 57 relative or unknown absolute configurations, 19 set-to-set linkages, 9 non-alditol open-chain residues, 2 unknown-position N-sulfates, 1 non-anomeric linkage, and 1 non-tree structure.

## Verification

- `air format .`
- Focused GlycoCT and WURCS test files
- Full `devtools::test()` suite
- `devtools::check(error_on = "warning", document = FALSE)`: 0 errors, 0 warnings, one environment-only clock-verification note
- Corpus revalidation of all 1,410 currently classified rows
- `git diff --check`
