### PR TITLE
Speed up GlyCAM IUPAC parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glyparse (development version)
 
+* `parse_glycam_iupac()` now parses large input vectors about five times faster.
 * New `parse_gwb()` parses GlycoWorkbench (GWB/GWS) sequences, including branches, substituents, furanose and configured residues, reducing-end alditols, and uncertain antennae. `auto_parse()` now detects these sequences. (#48)
 * `parse_glycoct()` now preserves repeated and alternative-position substituents, distinguishes N-acetyl and N-glycolyl from acetyl, maps generic `HexA` and `HexN` residues, and rejects unrepresentable non-alditol open-chain residues explicitly. (#47)
 * `parse_wurcs()` now accepts direct phosphate and alternative-position substituent encodings, preserves generic-root anomer positions, and orients ambiguous linkages using alditol-aware donor semantics. (#47)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glyparse (development version)
 
-* `parse_glycam_iupac()` now parses large input vectors about five times faster.
+* `parse_glycam_iupac()` now parses large input vectors about five times faster. (#49)
 * New `parse_gwb()` parses GlycoWorkbench (GWB/GWS) sequences, including branches, substituents, furanose and configured residues, reducing-end alditols, and uncertain antennae. `auto_parse()` now detects these sequences. (#48)
 * `parse_glycoct()` now preserves repeated and alternative-position substituents, distinguishes N-acetyl and N-glycolyl from acetyl, maps generic `HexA` and `HexN` residues, and rejects unrepresentable non-alditol open-chain residues explicitly. (#47)
 * `parse_wurcs()` now accepts direct phosphate and alternative-position substituent encodings, preserves generic-root anomer positions, and orients ambiguous linkages using alditol-aware donor semantics. (#47)

--- a/R/parse-glycam-iupac.R
+++ b/R/parse-glycam-iupac.R
@@ -80,8 +80,14 @@ convert_glycam_iupac_to_condensed <- function(x) {
     cli::cli_abort("Failed to parse the GlyCAM IUPAC string.")
   }
 
+  mono_map <- glycam_iupac_mono_map()
   purrr::map_chr(tokens, function(tokens) {
-    paste0(purrr::map_chr(tokens, convert_glycam_iupac_token), collapse = "")
+    converted <- purrr::map_chr(
+      tokens,
+      convert_glycam_iupac_token,
+      mono_map = mono_map
+    )
+    paste0(converted, collapse = "")
   })
 }
 
@@ -89,10 +95,14 @@ convert_glycam_iupac_to_condensed <- function(x) {
 #' Convert one GlyCAM IUPAC token to IUPAC-condensed notation
 #'
 #' @param token A GlyCAM residue token or branch bracket.
+#' @param mono_map A GlyCAM monosaccharide name map.
 #'
 #' @return A character scalar containing the converted token.
 #' @noRd
-convert_glycam_iupac_token <- function(token) {
+convert_glycam_iupac_token <- function(
+  token,
+  mono_map = glycam_iupac_mono_map()
+) {
   if (token %in% c("[", "]")) {
     return(token)
   }
@@ -103,7 +113,7 @@ convert_glycam_iupac_token <- function(token) {
     cli::cli_abort("Failed to parse GlyCAM IUPAC residue: {.val {token}}")
   }
 
-  mono <- convert_glycam_iupac_mono(residue_match[1, 2])
+  mono <- convert_glycam_iupac_mono(residue_match[1, 2], mono_map)
   modifiers <- convert_glycam_iupac_modifiers(
     stringr::str_extract_all(
       token,
@@ -162,12 +172,14 @@ is_glycam_iupac_reducing_end_moiety <- function(x) {
 #' Convert a GlyCAM monosaccharide name to a glyrepr monosaccharide name
 #'
 #' @param mono A GlyCAM monosaccharide label, such as `"DGlcpNAc"`.
+#' @param mono_map A GlyCAM monosaccharide name map.
 #'
 #' @return A glyrepr monosaccharide name.
 #' @noRd
-convert_glycam_iupac_mono <- function(mono) {
-  mono_map <- glycam_iupac_mono_map()
-
+convert_glycam_iupac_mono <- function(
+  mono,
+  mono_map = glycam_iupac_mono_map()
+) {
   converted <- unname(mono_map[[mono]])
   if (is.null(converted)) {
     cli::cli_abort("Unknown GlyCAM IUPAC monosaccharide: {.val {mono}}")


### PR DESCRIPTION
## Summary

Speed up `parse_glycam_iupac()` by reusing its monosaccharide mapping across all residues in an input vector. This brings GlyCAM throughput into the same range as the other IUPAC parsers without changing parsing behavior or public APIs.

## Rational

Profiling showed that rebuilding `glycam_iupac_mono_map()` for every residue accounted for approximately 96% of GlyCAM normalization time.

## Details

- Build the GlyCAM monosaccharide map once per input vector.
- Pass the shared map through the internal token and monosaccharide converters.
- Document the performance improvement in `NEWS.md`.

## Verification

- 300 distinct corpus structures: 24.4 to 132.9 structures/second.
- Median runtime: 12.319s to 2.258s, a 5.46x speedup.
- Canonical values and semantic graphs matched for all 300 structures.
- All 6,816 matched corpus records normalized successfully.
- Full test suite: 1,658 passed.
- R CMD check: 0 errors, 0 warnings; one environment-only system-clock NOTE.
